### PR TITLE
Take data providers into account when counting tests to be executed

### DIFF
--- a/tempto-core/src/main/java/com/teradata/tempto/internal/DataProviders.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/DataProviders.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.teradata.tempto.internal;
+
+import org.testng.ITestNGMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+import static java.util.Arrays.asList;
+
+/**
+ * Helper routines for working with TestNG data providers.
+ */
+public class DataProviders
+{
+
+    /**
+     * Obtains list of parameter sets for test method based on defined data provider.
+     * If no data provider is defined then {@link Optional#empty()} is returned.
+     * This method takes into consideration only data providers defined through annotation.
+     */
+    public static Optional<Object[][]> getParametersForMethod(ITestNGMethod method)
+    {
+        Test testAnnotation = method.getConstructorOrMethod().getMethod().getAnnotation(Test.class);
+        Class dataProviderClass = testAnnotation.dataProviderClass();
+        if (dataProviderClass == null || dataProviderClass == Object.class) {
+            dataProviderClass = method.getRealClass();
+        }
+        String dataProviderName = testAnnotation.dataProvider();
+        if (dataProviderName.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Optional<Method> dataProviderMethodOptional = asList(dataProviderClass.getMethods()).stream().filter(
+                m -> {
+                    DataProvider annotation = m.getAnnotation(DataProvider.class);
+                    return annotation != null && annotation.name().equals(dataProviderName);
+                }
+        ).findFirst();
+        if (dataProviderMethodOptional.isPresent()) {
+            try {
+                return Optional.of((Object[][]) dataProviderMethodOptional.get().invoke(null));
+            }
+            catch (Exception e) {
+                throw new RuntimeException("Exception while calling data provider for " + method, e);
+            }
+        }
+        else {
+            return Optional.empty();
+        }
+    }
+}

--- a/tempto-core/src/test/groovy/com/teradata/tempto/internal/DataProvidersTest.groovy
+++ b/tempto-core/src/test/groovy/com/teradata/tempto/internal/DataProvidersTest.groovy
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.teradata.tempto.internal
+
+import org.testng.ITestNGMethod
+import org.testng.annotations.DataProvider
+import org.testng.annotations.Test
+import org.testng.internal.ConstructorOrMethod
+import spock.lang.Specification
+
+class DataProvidersTest
+        extends Specification
+{
+  public static final Object[] EXTERNAL_DATA_PROVIDER_PARAMS = [["ex1"].toArray(), ["ex2"].toArray()].toArray()
+  public static final Object[] INTERNAL_DATA_PROVIDER_PARAMS = [["int1"].toArray(), ["int2"].toArray()].toArray()
+
+  private static class ExternalDataProviderClass
+  {
+    @DataProvider(name = "external_data_provider")
+    public static Object[][] externalDataProvider()
+    {
+      return EXTERNAL_DATA_PROVIDER_PARAMS
+    }
+  }
+
+  private static class TestClass
+  {
+
+    @DataProvider(name = "internal_data_provider")
+    public static Object[][] internalDataProvider()
+    {
+      return INTERNAL_DATA_PROVIDER_PARAMS
+    }
+
+    @Test
+    public void testMethodWithoutDataProvider()
+    {}
+
+    @Test(dataProvider = "internal_data_provider")
+    public void testMethodWithInternalDataProvider()
+    {}
+
+    @Test(dataProvider = "external_data_provider", dataProviderClass = ExternalDataProviderClass.class)
+    public void testMethodWithExternalDataProvider()
+    {}
+  }
+
+  def "should return absent for method without data provider"()
+  {
+    when:
+    ITestNGMethod mockTestNGMethod = mockTestNGMethod("testMethodWithoutDataProvider")
+    def parameters = DataProviders.getParametersForMethod(mockTestNGMethod)
+
+    then:
+    !parameters.isPresent()
+  }
+
+  def "should return parameters for method with internal data provider"()
+  {
+    when:
+    ITestNGMethod mockTestNGMethod = mockTestNGMethod("testMethodWithInternalDataProvider")
+    def parameters = DataProviders.getParametersForMethod(mockTestNGMethod)
+
+    then:
+    parameters.isPresent()
+    parameters.get() == INTERNAL_DATA_PROVIDER_PARAMS
+  }
+
+  def "should return parameters for method with external data provider"()
+  {
+    when:
+    ITestNGMethod mockTestNGMethod = mockTestNGMethod("testMethodWithExternalDataProvider")
+    def parameters = DataProviders.getParametersForMethod(mockTestNGMethod)
+
+    then:
+    parameters.isPresent()
+    parameters.get() == EXTERNAL_DATA_PROVIDER_PARAMS
+  }
+
+  private ITestNGMethod mockTestNGMethod(String testMethodName)
+  {
+    ITestNGMethod mockedTestNGMethod = Mock()
+    mockedTestNGMethod.getInstance() >> new TestClass()
+    mockedTestNGMethod.getRealClass() >> TestClass.class
+    ConstructorOrMethod mockedConstructorOrMethod = new ConstructorOrMethod(TestClass.getMethod(testMethodName))
+    mockedTestNGMethod.getConstructorOrMethod() >> mockedConstructorOrMethod
+    return mockedTestNGMethod
+  }
+}
+
+


### PR DESCRIPTION
Previously we counted method with data providers as single test
execution. Therefore all methods count was off and logs from
ProgressLoggingListener looked weird in such case.

Now we execute data provider within RequirementsExpanderInterceptor
which does the counting - and increment the seenMethodsCount by number
of paremeters sets.