### PR TITLE
core: MutableTableRequirementBuilder use LOADED as a default state

### DIFF
--- a/tempto-core/src/main/java/com/teradata/tempto/fulfillment/table/MutableTableRequirement.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/fulfillment/table/MutableTableRequirement.java
@@ -95,7 +95,7 @@ public class MutableTableRequirement
     {
         private final TableDefinition tableDefinition;
         private String name;
-        private State state;
+        private State state = LOADED;
 
         public MutableTableRequirementBuilder(TableDefinition tableDefinition)
         {


### PR DESCRIPTION
core: MutableTableRequirementBuilder use LOADED as a default state

Usage of builder without setting the state resulted with null pointer
exception during the build method.

Test Plan: none

Reviewers: losipiuk
