### PR TITLE
core: prefix mutable tables names in database with database name in convention tests

### DIFF
--- a/tempto-core/src/main/java/com/teradata/tempto/fulfillment/table/TablesState.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/fulfillment/table/TablesState.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -83,6 +84,11 @@ public abstract class TablesState
     {
         checkState(databaseTableInstances.containsKey(database), "There is no tables for database '%s'.", database);
         return databaseTableInstances.get(database);
+    }
+
+    public Set<String> getDatabaseNames()
+    {
+        return databaseTableInstances.keySet();
     }
 }
 

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/fulfillment/table/DatabaseTableInstanceMap.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/fulfillment/table/DatabaseTableInstanceMap.java
@@ -18,6 +18,7 @@ import com.teradata.tempto.fulfillment.table.TableInstance;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.beust.jcommander.internal.Maps.newHashMap;
 import static com.google.common.base.Preconditions.checkState;
@@ -57,5 +58,10 @@ public class DatabaseTableInstanceMap
     public Optional<TableInstance> get(String name)
     {
         return Optional.ofNullable(tableInstances.get(name));
+    }
+
+    public Set<String> getTableNames()
+    {
+        return tableInstances.keySet();
     }
 }

--- a/tempto-examples/src/main/resources/sql-tests/testcases/sample_table_insert/insert.sql
+++ b/tempto-examples/src/main/resources/sql-tests/testcases/sample_table_insert/insert.sql
@@ -1,14 +1,14 @@
 -- database: hive; tables: sample_hive_table; mutable_tables: sample_hive_table|created|sample_table_created, sample_hive_table|prepared|sample_table_prepared; groups: insert
 -- delimiter: |; ignoreOrder: false; types: INTEGER|VARCHAR
 --!
-INSERT INTO TABLE ${mutableTables.sample_table_created} SELECT * from sample_hive_table;
-SELECT * from ${mutableTables.sample_table_created}
+INSERT INTO TABLE ${mutableTables.hive.sample_table_created} SELECT * from sample_hive_table;
+SELECT * from ${mutableTables.hive.sample_table_created}
 --!
 1|A|
 2|B|
 3|C|
 --!
-CREATE TABLE ${mutableTables.sample_table_prepared} ROW FORMAT DELIMITED FIELDS TERMINATED BY '|' AS SELECT * from sample_hive_table;
+CREATE TABLE ${mutableTables.hive.sample_table_prepared} ROW FORMAT DELIMITED FIELDS TERMINATED BY '|' AS SELECT * from sample_hive_table;
 SELECT * from ${mutableTables.sample_table_prepared}
 --!
 1|A|


### PR DESCRIPTION
core: prefix mutable tables names in database with database name in convention tests

Previously queryExecutor database was used as default database for
mutable table names in database. Now we return all mutable tables, but
prefixed with database name where they exists.

Test Plan: manually running tests

Reviewers: losipiuk
