### PR TITLE
Add line escaping in AnnotatedFileParser

### DIFF
--- a/tempto-core/src/main/java/com/teradata/tempto/internal/convention/AnnotatedFileParser.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/convention/AnnotatedFileParser.java
@@ -72,6 +72,7 @@ public class AnnotatedFileParser
             .omitEmptyStrings()
             .trimResults()
             .withKeyValueSeparator(Splitter.on(":").trimResults());
+    public static final String LINE_ESCAPE = "\\";
 
     public List<SectionParsingResult> parseFile(Path path)
     {
@@ -144,8 +145,14 @@ public class AnnotatedFileParser
     {
         contentLines = contentLines.stream()
                 .filter(s -> !(isSpecialLine(s) || isBlank(s)))
+                .map(AnnotatedFileParser::unescapeLine)
                 .collect(toList());
         return contentLines;
+    }
+
+    private static String unescapeLine(String s)
+    {
+        return s.startsWith(LINE_ESCAPE) ? s.substring(1) : s;
     }
 
     private Map<String, String> parseLineProperties(String line)

--- a/tempto-core/src/test/groovy/com/teradata/tempto/internal/convention/AnnotatedFileParserTest.groovy
+++ b/tempto-core/src/test/groovy/com/teradata/tempto/internal/convention/AnnotatedFileParserTest.groovy
@@ -25,14 +25,17 @@ class AnnotatedFileParserTest
 {
   private AnnotatedFileParser fileParser = new AnnotatedFileParser()
 
-  def 'parse file with comments and properties'()
+  def 'parse file with comments, properties and whitespace lines'()
   {
     String fileContent = '-- property1: value1;\n' +
             '-- property2: value2\n' +
             'content line 1\n' +
             '--- comment line\n' +
+            '  \n' +  // whitespace line
             '--- property3: value3\n' +
-            'content line 2'
+            'content line 2\n' +
+            '\\--- contentproperty: x\n' +
+            '\\# content comment'
     SectionParsingResult parsingResult = parseOnlySection(fileContent)
 
     expect:
@@ -40,10 +43,12 @@ class AnnotatedFileParserTest
     parsingResult.getProperty("property2").get() == "value2"
     !parsingResult.getProperty("property3").isPresent()
     !parsingResult.getProperty("unknownProperty").isPresent()
-    parsingResult.getContentLines().size() == 2
+    parsingResult.getContentLines().size() == 4
     parsingResult.getContentLines().get(0) == "content line 1"
     parsingResult.getContentLines().get(1) == "content line 2"
-    parsingResult.getContentAsSingleLine() == "content line 1 content line 2"
+    parsingResult.getContentLines().get(2) == "--- contentproperty: x"
+    parsingResult.getContentLines().get(3) == "# content comment"
+    parsingResult.getContentAsSingleLine() == "content line 1 content line 2 --- contentproperty: x # content comment"
   }
 
   def 'parse file no comment properties'()


### PR DESCRIPTION
Add line escaping in AnnotatedFileParser

Sometimes we need to write common content line in .result file
which would be interpreted as special line by AnnotatedFileParser.
To be able to do this this patch adds line escape char ('\') which if
present at beginning of line is removed during parsing and remaining
part of line is treated as common content line.
