### PR TITLE
core: remove unused TestContext parameter from JdbcQueryExecutor constructor

### DIFF
--- a/tempto-core/src/main/java/com/teradata/tempto/query/JdbcQueryExecutor.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/query/JdbcQueryExecutor.java
@@ -49,7 +49,7 @@ public class JdbcQueryExecutor
         this.jdbcUrl = jdbcParamsState.url;
     }
 
-    public JdbcQueryExecutor(Connection connection, String jdbcUrl, TestContext testContext)
+    public JdbcQueryExecutor(Connection connection, String jdbcUrl)
     {
         this.connection = connection;
         this.jdbcUrl = jdbcUrl;


### PR DESCRIPTION
core: remove unused TestContext parameter from JdbcQueryExecutor constructor

Test Plan: none

Reviewers: ksobczak, sogorkis
