### PR TITLE
core: add posibility to use SshClient with pem file instead of password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ out/
 # tests logging output
 tempto_logs
 
+# tempto local configuration
+*-local.yaml
+
 # python packaging artifacts
 dist/
 

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/hadoop/hdfs/revisions/RevisionStorageProvider.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/hadoop/hdfs/revisions/RevisionStorageProvider.java
@@ -48,11 +48,11 @@ public class RevisionStorageProvider
     public RevisionStorage get()
     {
         if (xAttrsSupported()) {
-            LOGGER.info("HDFS xAttrs supported. Lets use RevisionMarkerXAttr.");
+            LOGGER.debug("HDFS xAttrs supported. Lets use RevisionMarkerXAttr.");
             return new RevisionStorageXAttr(hdfsClient, hdfsUser);
         }
         else {
-            LOGGER.info("HDFS xAttrs are not supported. Lets use RevisionMarkerFile.");
+            LOGGER.debug("HDFS xAttrs are not supported. Lets use RevisionMarkerFile.");
             return new RevisionStorageFile(hdfsClient, hdfsUser, testDataBasePath);
         }
     }

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/ssh/JschSshClientFactory.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/ssh/JschSshClientFactory.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.teradata.tempto.internal.ssh;
+
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+import com.teradata.tempto.ssh.SshClient;
+import com.teradata.tempto.ssh.SshClientFactory;
+import org.slf4j.Logger;
+
+import java.io.Serializable;
+import java.util.Optional;
+import java.util.Properties;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+public class JschSshClientFactory
+        implements SshClientFactory
+{
+    private static final Logger LOGGER = getLogger(JschSshClientFactory.class);
+
+    private final JSch jSch = new JSch();
+
+    @Override
+    public SshClient create(String host, int port, String user, Optional<String> password)
+    {
+        try {
+            String passwordToString = password.isPresent() ? '/' + password.get() : "";
+            LOGGER.debug("Allocating new SSH session to: {}{}@{}:{}", user, passwordToString, host, port);
+            Session session = jSch.getSession(user, host, port);
+            if (password.isPresent()) {
+                session.setPassword(password.get());
+            }
+            session.setConfig(getConfig());
+            return new JSchSshClient(session);
+        } catch (JSchException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void addIdentity(String pathToPem)
+    {
+        try {
+            LOGGER.debug("Adding SSH identity: {}", pathToPem);
+            jSch.addIdentity(pathToPem);
+        }
+        catch (JSchException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Properties getConfig()
+    {
+        Properties config = new Properties();
+        config.put("StrictHostKeyChecking", "no");
+        return config;
+    }
+}

--- a/tempto-core/src/main/java/com/teradata/tempto/ssh/SshClient.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/ssh/SshClient.java
@@ -15,13 +15,14 @@ package com.teradata.tempto.ssh;
 
 import com.teradata.tempto.process.CliProcess;
 
+import java.io.Closeable;
 import java.nio.file.Path;
 import java.util.List;
 
 /**
  * Simple SSH client.
  */
-public interface SshClient
+public interface SshClient extends Closeable
 {
     /**
      * Executes command on a remote machine.
@@ -41,4 +42,10 @@ public interface SshClient
      * @param remotePath Destination path for file on remote machine.
      */
     void upload(Path file, String remotePath);
+
+    String getHost();
+
+    String getUser();
+
+    int getPort();
 }

--- a/tempto-core/src/main/java/com/teradata/tempto/ssh/SshClientFactory.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/ssh/SshClientFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.teradata.tempto.ssh;
+
+import java.util.Optional;
+
+public interface SshClientFactory
+{
+    default SshClient create(String host) {
+        return create(host, 22, "root", Optional.empty());
+    }
+
+    default SshClient create(String host, int port) {
+        return create(host, port, "root", Optional.empty());
+    }
+
+    default SshClient create(String host, int port, String user) {
+        return create(host, port, user, Optional.empty());
+    }
+
+    SshClient create(String host, int port, String user, Optional<String> password);
+
+    void addIdentity(String pathToPem);
+}

--- a/tempto-examples/README.md
+++ b/tempto-examples/README.md
@@ -1,0 +1,45 @@
+# Tempto example tests
+
+## Running
+
+### Setup 
+
+ * setup clusters
+
+You need a cluster with hadoop accessible by name hadoop-master and a presto cluster accessible by name presto-master.
+
+Also you need PSQL instances.
+```
+docker run --name tempto-examples-psql -p 15432:5432 -e POSTGRES_USER=blah -e POSTGRES_PASSWORD=blah  -d postgres
+docker run --name tempto-examples-psql2 -p 15433:5432 -e POSTGRES_USER=blah -e POSTGRES_PASSWORD=blah  -d postgres
+
+# OR IF YOU ALREADY HAVE ABOVE DOCKER INSTANCES
+
+docker start tempto-examples-psql
+docker start tempto-examples-psql2
+```
+
+ * configure ssh in ```src/main/resources/tempto-configuration-local.yaml```
+
+You need a pem (private key) file to login to the cluster and some user with a password set (yarn/yarn by default).
+Example content for this file is:
+```
+ssh:
+  identity: ~/hfab/hfab/util/pkg_data/insecure_key.pem
+  roles:
+    host_by_password:
+      user: test
+      password: testtest
+      host: master
+
+    host_by_identity:
+      host: master
+```
+
+### build and run
+
+```
+cd tempto-examples
+gradle clean buildFatJar :third-party-deps:build
+../bin/tempto --tests-classpath build/libs/tempto-examples-all-${project.version}.jar:../third-party-deps/build/libs/hive-jdbc-all.jar:../third-party-deps/build/libs/presto-jdbc-all.jar --report-dir /tmp/report --tests-package com.teradata.tempto.example.*
+```

--- a/tempto-examples/src/main/java/com/teradata/tempto/examples/ExampleSshClientUsage.java
+++ b/tempto-examples/src/main/java/com/teradata/tempto/examples/ExampleSshClientUsage.java
@@ -15,35 +15,68 @@
 package com.teradata.tempto.examples;
 
 import com.google.inject.Inject;
+import com.teradata.tempto.ProductTest;
 import com.teradata.tempto.process.CliProcess;
 import com.teradata.tempto.ssh.SshClient;
+import com.teradata.tempto.ssh.SshClientFactory;
+import org.testng.annotations.Test;
 
 import javax.inject.Named;
 
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.concurrent.TimeoutException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class ExampleSshClientUsage
+        extends ProductTest
 {
-    private final SshClient sshClient;
+    @Inject
+    @Named("host_by_password")
+    private SshClient sshClientByPassword;
 
     @Inject
-    public ExampleSshClientUsage(@Named("td_express") SshClient sshClient) {
-        this.sshClient = sshClient;
-    }
+    @Named("host_by_identity")
+    private SshClient sshClientByIdentity;
 
-    public void execute(String command) {
-        try (CliProcess cliProcess = sshClient.execute(command)) {
-            // Within this method std::out,std::err will both be printed to the log
-            cliProcess.waitForWithTimeoutAndKill(Duration.ofMinutes(10));
-        } catch (InterruptedException | IOException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("Execution was interrupted", e);
+    @Inject
+    private SshClientFactory sshClientFactory;
+
+    @Test(groups = "ssh")
+    public void sshClientUsage()
+            throws Exception
+    {
+        sshClientByPassword.upload(Paths.get("build.gradle"), "/tmp");
+        try (CliProcess lsProcess = sshClientByIdentity.execute("ls /tmp/build.gradle")) {
+            lsProcess.waitForWithTimeoutAndKill();
         }
     }
 
-    public void upload(String what, String where) {
-        sshClient.upload(Paths.get(what), where);
+    @Test(groups = "ssh")
+    public void dynamicSshClient()
+            throws Exception
+    {
+        SshClient sshClient = sshClientFactory.create(sshClientByPassword.getHost());
+        try (CliProcess hostnameProcess = sshClient.execute("hostname")) {
+            assertThat(hostnameProcess.nextOutputLine()).contains(sshClientByIdentity.getHost());
+            hostnameProcess.waitForWithTimeoutAndKill();
+        }
+    }
+
+    @Test(groups = "ssh")
+    public void longRunningCommandTimeout()
+            throws Exception
+    {
+        try (CliProcess cliProcess = sshClientByPassword.execute("sleep 30")) {
+            // Within this method std::out,std::err will both be printed to the log
+            cliProcess.waitForWithTimeoutAndKill(Duration.ofSeconds(10));
+            fail("This command should timeout!");
+        }
+        catch (RuntimeException e) {
+            assertThat(e.getMessage()).contains("did not finish within given timeout");
+        }
     }
 }

--- a/tempto-examples/src/main/resources/tempto-configuration.yaml
+++ b/tempto-examples/src/main/resources/tempto-configuration.yaml
@@ -25,8 +25,6 @@ databases:
     jdbc_pooling: false
     jdbc_jar: third-party-deps/build/libs/presto-jdbc-all.jar
 
-  # run psql instance with
-  # docker run --name tempto-examples-psql -p 15432:5432 -e POSTGRES_USER=blah -e POSTGRES_PASSWORD=blah  -d postgres
   psql:
     jdbc_driver_class: org.postgresql.Driver
     jdbc_url: jdbc:postgresql://localhost:15432/postgres
@@ -35,8 +33,6 @@ databases:
     jdbc_pooling: true
     table_manager_type: jdbc
 
-  # run psql2 instance with
-  # docker run --name tempto-examples-psql2 -p 15433:5432 -e POSTGRES_USER=blah -e POSTGRES_PASSWORD=blah  -d postgres
   psql2:
     jdbc_driver_class: org.postgresql.Driver
     jdbc_url: jdbc:postgresql://localhost:15433/postgres
@@ -49,9 +45,16 @@ tests:
   hdfs:
     path: /tempto
 
-ssh_roles:
-  td_express:
-    host: ${TD_EXPRESS_HOST}
-    port: 22
-    user: root
-    password: root
+ssh:
+  identity: ${IDENTITY}
+  roles:
+    host_by_password:
+      host: ${HOST}
+      port: 22
+      user: ${USER_A}
+      password: ${USER_A_PASSWORD}
+
+    host_by_identity:
+      host: ${HOST}
+      port: 22
+      user: ${USER_B}


### PR DESCRIPTION
core: add posibility to use SshClient with pem file instead of password

Moreover now user can inject into test SshClientFactory so he can create
SshClient dynamically.

Note that, when you port your tempto to version 1.0.35 and you use
SssClient then you need to modify your tempto-configuration.yaml.

Test Plan: using SshClient with pem file in tests

Reviewers: ksobczak, losipiuk, arosa
