### PR TITLE
ssh: throw explicit exceptions on timeout and command failure

### DIFF
--- a/tempto-core/src/main/java/com/teradata/tempto/internal/process/CliProcessBase.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/process/CliProcessBase.java
@@ -61,7 +61,7 @@ public abstract class CliProcessBase
     public String nextOutputLine()
     {
         String nextLine = processOutput.nextLine();
-        LOGGER.info("processOutput: {}", nextLine);
+        LOGGER.debug("processOutput: {}", nextLine);
         return nextLine;
     }
 
@@ -69,7 +69,7 @@ public abstract class CliProcessBase
     public String nextOutputToken()
     {
         String next = processOutput.next();
-        LOGGER.info("processOutput: {}", next);
+        LOGGER.debug("processOutput: {}", next);
         return next;
     }
 

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/ssh/JSchCliProcess.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/ssh/JSchCliProcess.java
@@ -16,6 +16,8 @@ package com.teradata.tempto.internal.ssh;
 import com.jcraft.jsch.ChannelExec;
 import com.jcraft.jsch.JSchException;
 import com.teradata.tempto.internal.process.CliProcessBase;
+import com.teradata.tempto.process.CommandExecutionException;
+import com.teradata.tempto.process.TimeoutRuntimeException;
 import org.slf4j.Logger;
 
 import java.io.IOException;
@@ -67,13 +69,13 @@ class JSchCliProcess
         if (!channel.isClosed()) {
             close();
             thread.join();
-            throw new RuntimeException("SSH channel did not finish within given timeout");
+            throw new TimeoutRuntimeException("SSH channel did not finish within given timeout");
         }
 
         close();
         int exitStatus = channel.getExitStatus();
         if (channel.getExitStatus() != 0) {
-            throw new RuntimeException("SSH command exited with status: " + exitStatus);
+            throw new CommandExecutionException("SSH command exited with status: " + exitStatus, exitStatus);
         }
     }
 

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/ssh/JSchSshClient.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/ssh/JSchSshClient.java
@@ -20,6 +20,7 @@ import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
 import com.teradata.tempto.process.CliProcess;
 import com.teradata.tempto.ssh.SshClient;
+import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,6 +32,7 @@ import java.util.List;
 import static com.google.common.collect.Iterables.transform;
 import static java.nio.file.Files.newInputStream;
 import static java.util.Objects.requireNonNull;
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * An {@link SshClient} based on JSch library.
@@ -38,6 +40,8 @@ import static java.util.Objects.requireNonNull;
 public class JSchSshClient
         implements SshClient
 {
+    private static final Logger LOGGER = getLogger(JSchSshClient.class);
+
     private final Session session;
 
     public JSchSshClient(Session session)
@@ -55,6 +59,7 @@ public class JSchSshClient
     public CliProcess execute(String command)
     {
         try {
+            LOGGER.info("Executing on {}@{}: {}", getUser(), getHost(), command);
             ChannelExec channel = (ChannelExec) getActiveSession().openChannel("exec");
             channel.setCommand(command);
             JSchCliProcess process = new JSchCliProcess(channel);
@@ -78,6 +83,7 @@ public class JSchSshClient
     @Override
     public void upload(Path file, String remotePath)
     {
+        LOGGER.info("Uploading {} onto {}@{}:{}", file, getUser(), getHost(), remotePath);
         try {
             ChannelExec channel = (ChannelExec) getActiveSession().openChannel("exec");
             String command = "scp -t " + remotePath;

--- a/tempto-core/src/main/java/com/teradata/tempto/process/CliProcess.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/process/CliProcess.java
@@ -59,13 +59,15 @@ public interface CliProcess extends Closeable
 
     /**
      * Waits for a process to finish and ensures it returns with 0 status. If the process
-     * fails to finish within given timeout it is killed and {@link RuntimeException} is thrown.
+     * fails to finish within given timeout it is killed and {@link TimeoutRuntimeException} is thrown.
      *
      * @throws InterruptedException if the thread is interrupted
+     * @throws CommandExecutionException if command finishes with non zero status
+     * @throws TimeoutRuntimeException
      */
     void waitForWithTimeoutAndKill()
-            throws InterruptedException;
+            throws InterruptedException, TimeoutRuntimeException, CommandExecutionException;
 
     void waitForWithTimeoutAndKill(Duration timeout)
-            throws InterruptedException;
+            throws InterruptedException, TimeoutRuntimeException, CommandExecutionException;
 }

--- a/tempto-core/src/main/java/com/teradata/tempto/process/CommandExecutionException.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/process/CommandExecutionException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.teradata.tempto.process;
+
+public class CommandExecutionException
+        extends RuntimeException
+{
+    private final int exitStatus;
+
+    public CommandExecutionException(String message, int exitStatus)
+    {
+        super(message);
+        this.exitStatus = exitStatus;
+    }
+
+    public int getExitStatus()
+    {
+        return exitStatus;
+    }
+}

--- a/tempto-core/src/main/java/com/teradata/tempto/process/TimeoutRuntimeException.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/process/TimeoutRuntimeException.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.teradata.tempto.process;
+
+public class TimeoutRuntimeException
+        extends RuntimeException
+{
+    public TimeoutRuntimeException(String msg)
+    {
+        super(msg);
+    }
+}


### PR DESCRIPTION
ssh: throw explicit exceptions on timeout and command failure

Throwing explicit exception in case of command timeout or command
execution failure. Thanks to that user is able to handle this in
more elegant way than catching the RuntimeException.

Additionally, log command output (as debug) and log commands passed via
ssh.

Test Plan: run product tests which are using ssh

Reviewers: losipiuk
