### PR TITLE
examples: remove failing test

### DIFF
--- a/tempto-examples/README.md
+++ b/tempto-examples/README.md
@@ -46,4 +46,3 @@ gradle clean build
 
 The framework will print on your console whether a test passed or failed. A more detailed report
 is available at `/tmp/report/index.html`. 
-Note that one test (`com.teradata.tempto.examples.SimpleQueryTest.failingTest`) is made to fail on purpose.

--- a/tempto-examples/src/main/java/com/teradata/tempto/examples/SimpleQueryTest.java
+++ b/tempto-examples/src/main/java/com/teradata/tempto/examples/SimpleQueryTest.java
@@ -137,12 +137,6 @@ public class SimpleQueryTest
         assertThat(query("select * from " + tableInstance.getNameInDatabase())).hasAnyRows();
     }
 
-    @Test(groups = "failing")
-    public void failingTest()
-    {
-        assertThat(1).isEqualTo(2);
-    }
-
     @Test(groups = "skipped", enabled = false)
     public void disabledTest()
     {


### PR DESCRIPTION
examples: remove failing test

Having failing test failing in automation may hide other failures.

Task: SWARM-1404

Test Plan: build

Reviewers: losipiuk
