### PR TITLE
Ensure sessions cresated by JSchSshClient are closed

### DIFF
--- a/tempto-core/src/main/java/com/teradata/tempto/internal/initialization/TestInitializationListener.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/initialization/TestInitializationListener.java
@@ -19,11 +19,8 @@ import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.inject.Binder;
-import com.google.inject.Injector;
-import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Singleton;
-import com.google.inject.name.Named;
 import com.teradata.tempto.AfterTestWithContext;
 import com.teradata.tempto.BeforeTestWithContext;
 import com.teradata.tempto.Requirement;
@@ -52,7 +49,6 @@ import org.testng.ITestResult;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -65,6 +61,7 @@ import static com.teradata.tempto.context.TestContextDsl.runWithTestContext;
 import static com.teradata.tempto.context.ThreadLocalTestContextHolder.assertTestContextNotSet;
 import static com.teradata.tempto.context.ThreadLocalTestContextHolder.popAllTestContexts;
 import static com.teradata.tempto.context.ThreadLocalTestContextHolder.pushAllTestContexts;
+import static com.teradata.tempto.context.ThreadLocalTestContextHolder.testContext;
 import static com.teradata.tempto.context.ThreadLocalTestContextHolder.testContextIfSet;
 import static com.teradata.tempto.internal.ReflectionHelper.getAnnotatedSubTypesOf;
 import static com.teradata.tempto.internal.ReflectionHelper.instantiate;
@@ -238,12 +235,11 @@ public class TestInitializationListener
             return;
         }
 
-        TestContextStack<GuiceTestContext> testContextStack = (TestContextStack) popAllTestContexts();
-
         try {
-            runAfterWithContextMethods(testResult, testContextStack.peek());
+            runAfterWithContextMethods(testResult, (GuiceTestContext) testContext());
         }
         finally {
+            TestContextStack<GuiceTestContext> testContextStack = (TestContextStack) popAllTestContexts();
             doCleanup(testContextStack, testMethodLevelFulfillers);
             cleanLoggingMdc();
         }

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/ssh/JSchCliProcess.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/ssh/JSchCliProcess.java
@@ -15,6 +15,7 @@ package com.teradata.tempto.internal.ssh;
 
 import com.jcraft.jsch.ChannelExec;
 import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
 import com.teradata.tempto.internal.process.CliProcessBase;
 import com.teradata.tempto.process.CommandExecutionException;
 import com.teradata.tempto.process.TimeoutRuntimeException;
@@ -31,12 +32,14 @@ class JSchCliProcess
 {
     private static final Logger LOGGER = getLogger(JSchCliProcess.class);
 
+    private final Session session;
     private final ChannelExec channel;
 
-    JSchCliProcess(ChannelExec channel)
+    JSchCliProcess(Session session, ChannelExec channel)
             throws IOException
     {
         super(channel.getInputStream(), channel.getErrStream() , channel.getOutputStream());
+        this.session = session;
         this.channel = channel;
     }
 
@@ -85,10 +88,14 @@ class JSchCliProcess
     @Override
     public void close()
     {
-        // close channel first
-        channel.disconnect();
-
-        // close all related streams than
-        super.close();
+        try {
+            channel.disconnect();
+        } finally {
+            try {
+                session.disconnect();
+            } finally {
+                super.close();
+            }
+        }
     }
 }

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/ssh/JschSshClientFactory.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/ssh/JschSshClientFactory.java
@@ -36,18 +36,21 @@ public class JschSshClientFactory
     @Override
     public SshClient create(String host, int port, String user, Optional<String> password)
     {
-        try {
-            String passwordToString = password.isPresent() ? '/' + password.get() : "";
-            LOGGER.debug("Allocating new SSH session to: {}{}@{}:{}", user, passwordToString, host, port);
-            Session session = jSch.getSession(user, host, port);
-            if (password.isPresent()) {
-                session.setPassword(password.get());
+        return new JSchSshClient(() -> {
+            try {
+                String passwordToString = password.isPresent() ? '/' + password.get() : "";
+                LOGGER.debug("Allocating new SSH session to: {}{}@{}:{}", user, passwordToString, host, port);
+                Session session = jSch.getSession(user, host, port);
+                if (password.isPresent()) {
+                    session.setPassword(password.get());
+                }
+                session.setConfig(getConfig());
+                return session;
             }
-            session.setConfig(getConfig());
-            return new JSchSshClient(session);
-        } catch (JSchException e) {
-            throw new RuntimeException(e);
-        }
+            catch (JSchException e) {
+                throw new RuntimeException(e);
+            }
+        });
     }
 
     @Override

--- a/tempto-core/src/main/java/com/teradata/tempto/ssh/SshClient.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/ssh/SshClient.java
@@ -56,10 +56,4 @@ public interface SshClient extends Closeable
      * @param remotePath Destination path for file on remote machine.
      */
     void upload(Path file, String remotePath);
-
-    String getHost();
-
-    String getUser();
-
-    int getPort();
 }

--- a/tempto-core/src/main/java/com/teradata/tempto/ssh/SshClientFactory.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/ssh/SshClientFactory.java
@@ -18,12 +18,15 @@ import java.util.Optional;
 
 public interface SshClientFactory
 {
+
+    String DEFAULT_USER = "root";
+
     default SshClient create(String host) {
-        return create(host, 22, "root", Optional.empty());
+        return create(host, 22, DEFAULT_USER, Optional.empty());
     }
 
     default SshClient create(String host, int port) {
-        return create(host, port, "root", Optional.empty());
+        return create(host, port, DEFAULT_USER, Optional.empty());
     }
 
     default SshClient create(String host, int port, String user) {

--- a/tempto-examples/src/main/java/com/teradata/tempto/examples/ExampleSshClientUsage.java
+++ b/tempto-examples/src/main/java/com/teradata/tempto/examples/ExampleSshClientUsage.java
@@ -45,6 +45,14 @@ public class ExampleSshClientUsage
     @Inject
     private SshClientFactory sshClientFactory;
 
+    @Inject
+    @Named("ssh.roles.host_by_password.host")
+    private String hostByPassword;
+
+    @Inject
+    @Named("ssh.roles.host_by_identity.host")
+    private String hostByIdentity;
+
     @Test(groups = "ssh")
     public void sshClientUsage()
             throws Exception
@@ -59,9 +67,9 @@ public class ExampleSshClientUsage
     public void dynamicSshClient()
             throws Exception
     {
-        SshClient sshClient = sshClientFactory.create(sshClientByPassword.getHost());
+        SshClient sshClient = sshClientFactory.create(hostByPassword);
         try (CliProcess hostnameProcess = sshClient.execute("hostname")) {
-            assertThat(hostnameProcess.nextOutputLine()).contains(sshClientByIdentity.getHost());
+            assertThat(hostnameProcess.nextOutputLine()).contains(hostByIdentity);
             hostnameProcess.waitForWithTimeoutAndKill();
         }
     }


### PR DESCRIPTION
Ensure sessions cresated by JSchSshClient are closed

This patch changes behaviour of JSchSshClient so sessions are created on
per process/upload basis and closed immediatyly after procss/upload is
completed.

Additionally we set JSch threads as daemon so JVM would still exit if
some JSch threads are hanging around. This can be an issue in example
when test timeout occurs.

Reviewers: gkokosinski
