### PR TITLE
examples: use /etc/hosts instead build.gradle in ssh usage example

### DIFF
--- a/tempto-examples/src/main/java/com/teradata/tempto/examples/ExampleSshClientUsage.java
+++ b/tempto-examples/src/main/java/com/teradata/tempto/examples/ExampleSshClientUsage.java
@@ -23,11 +23,11 @@ import org.testng.annotations.Test;
 
 import javax.inject.Named;
 
-import java.io.IOException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
-import java.util.concurrent.TimeoutException;
 
+import static java.nio.file.Files.readAllLines;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -57,9 +57,11 @@ public class ExampleSshClientUsage
     public void sshClientUsage()
             throws Exception
     {
-        sshClientByPassword.upload(Paths.get("build.gradle"), "/tmp");
-        try (CliProcess lsProcess = sshClientByIdentity.execute("ls /tmp/build.gradle")) {
-            lsProcess.waitForWithTimeoutAndKill();
+        Path etcHosts = Paths.get("/etc/hosts");
+        sshClientByPassword.upload(etcHosts, "/tmp");
+        try (CliProcess catProcess = sshClientByIdentity.execute("cat /tmp/hosts")) {
+            assertThat(catProcess.readRemainingOutputLines()).isNotEqualTo(readAllLines(etcHosts));
+            catProcess.waitForWithTimeoutAndKill();
         }
     }
 


### PR DESCRIPTION
examples: use /etc/hosts instead build.gradle in ssh usage example

build.gradle file is inaccessible when examples are run within a docker.

Test Plan: build

Reviewers: losipiuk
