### PR TITLE
examples: fix in TpchDataSourceTest

### DIFF
--- a/tempto-examples/src/main/java/com/teradata/tempto/examples/TpchDataSourceTest.java
+++ b/tempto-examples/src/main/java/com/teradata/tempto/examples/TpchDataSourceTest.java
@@ -40,7 +40,7 @@ public class TpchDataSourceTest
 
         String path = "/tempto/" + dataSource.getPathSuffix();
 
-        assertThat(path).isEqualTo("/tempto/tpch/sf-1,00/REGION");
+        assertThat(path).isEqualTo("/tempto/tpch/sf-1_00/REGION");
 
         HdfsClient hdfsClient = testContext().getDependency(HdfsClient.class);
         String hdfsUsername = testContext().getDependency(String.class, "hdfs.username");


### PR DESCRIPTION
examples: fix in TpchDataSourceTest

Fix number separator to match the one used in TpchDataSource.

Test Plan: build

Reviewers: losipiuk
