### PR TITLE
Allow users to specify fulfillers before built-in fulfillers

### DIFF
--- a/tempto-core/src/main/java/com/teradata/tempto/fulfillment/RequirementFulfiller.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/fulfillment/RequirementFulfiller.java
@@ -37,7 +37,7 @@ public interface RequirementFulfiller
     {
         /**
          * With priority you can manage the order of fulfiller execution.
-         * With higher priority fulfiller will {@link com.teradata.tempto.fulfillment.RequirementFulfiller#fulfill} sooner
+         * With lower priority fulfiller will {@link com.teradata.tempto.fulfillment.RequirementFulfiller#fulfill} sooner
          * and {@link com.teradata.tempto.fulfillment.RequirementFulfiller#cleanup()} later.
          *
          * @return priority level
@@ -54,7 +54,7 @@ public interface RequirementFulfiller
     {
         /**
          * With priority you can manage the order of fulfiller execution.
-         * With higher priority fulfiller will {@link com.teradata.tempto.fulfillment.RequirementFulfiller#fulfill} sooner
+         * With lower priority fulfiller will {@link com.teradata.tempto.fulfillment.RequirementFulfiller#fulfill} sooner
          * and {@link com.teradata.tempto.fulfillment.RequirementFulfiller#cleanup()} later.
          *
          * @return priority level

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/RequirementFulfillerByPriorityComparator.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/RequirementFulfillerByPriorityComparator.java
@@ -15,10 +15,10 @@
 package com.teradata.tempto.internal;
 
 import com.teradata.tempto.fulfillment.RequirementFulfiller;
-import com.teradata.tempto.fulfillment.RequirementFulfiller.AutoSuiteLevelFulfiller;
-import com.teradata.tempto.fulfillment.RequirementFulfiller.AutoTestLevelFulfiller;
 
 import java.util.Comparator;
+
+import static com.teradata.tempto.internal.RequirementFulfillerPriorityHelper.getPriority;
 
 public class RequirementFulfillerByPriorityComparator
         implements Comparator<Class<? extends RequirementFulfiller>>
@@ -28,20 +28,5 @@ public class RequirementFulfillerByPriorityComparator
     public int compare(Class<? extends RequirementFulfiller> o1, Class<? extends RequirementFulfiller> o2)
     {
         return getPriority(o1) - getPriority(o2);
-    }
-
-    private int getPriority(Class<? extends RequirementFulfiller> c)
-    {
-        if (c.getAnnotation(AutoSuiteLevelFulfiller.class) != null) {
-            return c.getAnnotation(AutoSuiteLevelFulfiller.class).priority();
-        }
-        else if (c.getAnnotation(AutoTestLevelFulfiller.class) != null) {
-            return c.getAnnotation(AutoTestLevelFulfiller.class).priority();
-        }
-        else {
-            throw new RuntimeException(
-                    String.format("Class '%s' is not annotated with '%' or '%s'.",
-                            c.getName(), AutoSuiteLevelFulfiller.class.getName(), AutoTestLevelFulfiller.class.getName()));
-        }
     }
 }

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/RequirementFulfillerPriorityHelper.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/RequirementFulfillerPriorityHelper.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.teradata.tempto.internal;
+
+import com.teradata.tempto.fulfillment.RequirementFulfiller;
+
+public class RequirementFulfillerPriorityHelper
+{
+    public static int getPriority(Class<? extends RequirementFulfiller> c)
+    {
+        if (c.getAnnotation(RequirementFulfiller.AutoSuiteLevelFulfiller.class) != null) {
+            return c.getAnnotation(RequirementFulfiller.AutoSuiteLevelFulfiller.class).priority();
+        }
+        else if (c.getAnnotation(RequirementFulfiller.AutoTestLevelFulfiller.class) != null) {
+            return c.getAnnotation(RequirementFulfiller.AutoTestLevelFulfiller.class).priority();
+        }
+        else {
+            throw new RuntimeException(
+                    String.format("Class '%s' is not annotated with '%' or '%s'.",
+                            c.getName(), RequirementFulfiller.AutoSuiteLevelFulfiller.class.getName(), RequirementFulfiller.AutoTestLevelFulfiller.class.getName()));
+        }
+    }
+}


### PR DESCRIPTION
Allow users to specify fulfillers before built-in fulfillers

Sometimes, users will want to specify a fulfiller before a built-in
fulfillers (e.g. if a certain database user needs to be created
before creating the tables). So, we adjust priorities such that
lower priorities are fulfilled sooner.

The order is:
* negative user-defined priorities
* built-in fulfillers
* >= 0 user-defined priorities

Testing: unit tests
