### PR TITLE
Don't drop and recreate immutable JDBC tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,13 +176,16 @@ databases:           # database connections
     jdbc_user: hdfs
     jdbc_password: na
 
-  psql:           # posgresql
+  psql:           # postgresql
     jdbc_driver_class: org.postgresql.Driver
     jdbc_url: jdbc:postgresql://localhost:5432/postgres
     jdbc_user: blah
     jdbc_password: blah
     jdbc_pooling: true
     table_manager_type: jdbc
+    # (optional) flag to skip schema creation, if a given database does not support
+    # CREATE SCHEMA IF EXISTS syntax
+    skip_create_schema: true
 
 ```
 

--- a/tempto-core/src/test/groovy/com/teradata/tempto/fulfillment/table/JdbcTableManagerTest.groovy
+++ b/tempto-core/src/test/groovy/com/teradata/tempto/fulfillment/table/JdbcTableManagerTest.groovy
@@ -21,6 +21,10 @@ import com.teradata.tempto.internal.fulfillment.table.jdbc.JdbcTableManager
 import com.teradata.tempto.query.QueryExecutor
 import spock.lang.Specification
 
+import java.sql.Connection
+import java.sql.DatabaseMetaData
+import java.sql.ResultSet
+
 public class JdbcTableManagerTest
         extends Specification
 {
@@ -33,7 +37,14 @@ public class JdbcTableManagerTest
     tableName = "name"
     tableDefinition = JdbcTableDefinition.jdbcTableDefinition(tableName, "CREATE TABLE %NAME%(col1 INT)",
             { Collections.<List<Object>>emptyList().iterator() } as JdbcTableDataSource)
-    tableManager = new JdbcTableManager(Mock(QueryExecutor), new TableNameGenerator(), "db_name")
+
+    def mockExecutor = Mock(QueryExecutor)
+    def mockConnection = Mock(Connection)
+    def mockMetadata = Mock(DatabaseMetaData)
+    mockExecutor.connection >> mockConnection
+    mockConnection.getMetaData() >> mockMetadata
+    mockMetadata.getTables(_, _, _, _) >> Mock(ResultSet)
+    tableManager = new JdbcTableManager(mockExecutor, new TableNameGenerator(), "db_name")
   }
 
   def 'table without rows does not throw'()

--- a/tempto-core/src/test/groovy/com/teradata/tempto/fulfillment/table/JdbcTableManagerTest.groovy
+++ b/tempto-core/src/test/groovy/com/teradata/tempto/fulfillment/table/JdbcTableManagerTest.groovy
@@ -16,6 +16,7 @@ package com.teradata.tempto.fulfillment.table
 
 import com.teradata.tempto.fulfillment.table.jdbc.JdbcTableDataSource
 import com.teradata.tempto.fulfillment.table.jdbc.JdbcTableDefinition
+import com.teradata.tempto.internal.configuration.EmptyConfiguration
 import com.teradata.tempto.internal.fulfillment.table.TableNameGenerator
 import com.teradata.tempto.internal.fulfillment.table.jdbc.JdbcTableManager
 import com.teradata.tempto.query.QueryExecutor
@@ -24,6 +25,7 @@ import spock.lang.Specification
 import java.sql.Connection
 import java.sql.DatabaseMetaData
 import java.sql.ResultSet
+import java.sql.ResultSetMetaData
 
 public class JdbcTableManagerTest
         extends Specification
@@ -43,8 +45,11 @@ public class JdbcTableManagerTest
     def mockMetadata = Mock(DatabaseMetaData)
     mockExecutor.connection >> mockConnection
     mockConnection.getMetaData() >> mockMetadata
-    mockMetadata.getTables(_, _, _, _) >> Mock(ResultSet)
-    tableManager = new JdbcTableManager(mockExecutor, new TableNameGenerator(), "db_name")
+
+    def mockResultSet = Mock(ResultSet)
+    mockMetadata.getTables(_, _, _, _) >> mockResultSet
+    mockResultSet.getMetaData() >> Mock(ResultSetMetaData)
+    tableManager = new JdbcTableManager(mockExecutor, new TableNameGenerator(), "db_name", EmptyConfiguration.emptyConfiguration())
   }
 
   def 'table without rows does not throw'()


### PR DESCRIPTION
JDBC tables take a long time to reload, since they are loaded via prepared
statements, so don't drop them every time. A future extension would be to
drop and recreate the table if the underlying data has changed.