### PR TITLE
Timestamp fix

### DIFF
--- a/tempto-core/src/main/java/com/teradata/tempto/internal/initialization/TestInitializationListener.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/initialization/TestInitializationListener.java
@@ -53,6 +53,7 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TimeZone;
 
 import static com.beust.jcommander.internal.Lists.newArrayList;
 import static com.google.common.base.Preconditions.checkState;
@@ -172,6 +173,7 @@ public class TestInitializationListener
     @Override
     public void onStart(ITestContext context)
     {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
         Module suiteModule = combine(combine(getSuiteModules()), bind(suiteLevelFulfillers), bind(testMethodLevelFulfillers));
         GuiceTestContext initSuiteTestContext = new GuiceTestContext(suiteModule);
         TestContextStack<GuiceTestContext> suiteTextContextStack = new TestContextStack<>();


### PR DESCRIPTION
creating a new timestamp class that prints timestamp in UTC instead of local

Edit: providing a description, had communicated with others before. 

Tested for "timestamp" field with no timezone information. 
Following example scenario happens currently: 
1. input in data file (.data file) is "2014-02-01 23:59:21"
2. tempto creates a Timestamp object using DateTimeUtils.parseTimestampInUTC(), the processing is correct. 
3. tempto inserts Timestamp object to teradata, using Timestamp.toString() value
4. But, Timestamp.toString() prints "2014-02-01 18:59:21.0" which is local equivalent in EST
5. Database stores "2014-02-01 18:59:21.0"
6. select query via tempto when using onPresto() returns "2014-02-01 13:59:21.0", which is due to Presto converting the timestamp from UTC to local (EST). 
7. So, final value returned by tempto is "2014-02-01 13:59:21.0". This value is 2 timezones  (2 x 5hours offset for EST) away from the original value of  "2014-02-01 23:59:21"

So the consensus was, if in step 5, if the database contains original timestamp i.e.  "2014-02-01 23:59:21", then we can do correct output comparison. 

More investigation showed that the Timestamp object in DateTimeUtils.parseTimestampInUTC() processes the UTC timezone information correctly, but when printing by its toString() function, it prints the local timestamp.

Therefore, the patch contains a Timestamp class definition that overrides Timestamp.toString() function to print the correct timestamp to be inserted to database. 

Something similar is discussed here also: 
http://stackoverflow.com/questions/18604989/utc-timestamp-joda-time

