### PR TITLE
Single float tolerance in comparison fix

### DIFF
--- a/tempto-core/src/main/java/com/teradata/tempto/internal/query/QueryResultValueComparator.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/query/QueryResultValueComparator.java
@@ -14,6 +14,7 @@
 
 package com.teradata.tempto.internal.query;
 
+import com.google.common.base.Throwables;
 import com.google.common.math.DoubleMath;
 import com.google.common.primitives.UnsignedBytes;
 
@@ -105,28 +106,28 @@ public class QueryResultValueComparator
 
     private int arrayEqual(Object actual, Object expected)
     {
-        if (actual instanceof Array && expected instanceof List) {
-            Array actualArray = (Array) actual;
-            QueryResultValueComparator elementComparator;
-            elementComparator = comparatorForArrayElements(actualArray);
-            List actualList = arrayAsList(actualArray);
-            List expectedList = (List) expected;
-
-            if (actualList.size() != expectedList.size()) {
-                return -1;
-            }
-
-            for (int i = 0; i < actualList.size(); ++i) {
-                Object actualValue = actualList.get(i);
-                Object expectedValue = expectedList.get(i);
-                int compareResult = elementComparator.compare(actualValue, expectedValue);
-                if (compareResult != 0) {
-                    return compareResult;
-                }
-            }
-            return 0;
+        if (!(actual instanceof Array && expected instanceof List)) {
+            return -1;
         }
-        return -1;
+        Array actualArray = (Array) actual;
+        QueryResultValueComparator elementComparator;
+        elementComparator = comparatorForArrayElements(actualArray);
+        List actualList = arrayAsList(actualArray);
+        List expectedList = (List) expected;
+
+        if (actualList.size() != expectedList.size()) {
+            return -1;
+        }
+
+        for (int i = 0; i < actualList.size(); ++i) {
+            Object actualValue = actualList.get(i);
+            Object expectedValue = expectedList.get(i);
+            int compareResult = elementComparator.compare(actualValue, expectedValue);
+            if (compareResult != 0) {
+                return compareResult;
+            }
+        }
+        return 0;
     }
 
     private QueryResultValueComparator comparatorForArrayElements(Array actualArray)
@@ -136,7 +137,7 @@ public class QueryResultValueComparator
             elementComparator = comparatorForType(JDBCType.valueOf(actualArray.getBaseType()));
         }
         catch (SQLException e) {
-            throw new RuntimeException();
+            throw Throwables.propagate(e);
         }
         return elementComparator;
     }
@@ -147,7 +148,7 @@ public class QueryResultValueComparator
             return Arrays.asList((Object[])array.getArray());
         }
         catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw Throwables.propagate(e);
         }
     }
 

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/query/QueryResultValueComparator.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/query/QueryResultValueComparator.java
@@ -177,12 +177,12 @@ public class QueryResultValueComparator
 
     private int longEqual(Object actual, Object expected)
     {
-        if (isIntegerValue(actual) && isIntegerValue(expected)) {
-            Long actualLong = Long.valueOf(actual.toString());
-            Long expectedLong = Long.valueOf(expected.toString());
-            return actualLong.compareTo(expectedLong);
+        if (!(isIntegerValue(actual) && isIntegerValue(expected))) {
+            return -1;
         }
-        return -1;
+        Long actualLong = getLongValue(actual);
+        Long expectedLong = getLongValue(expected);
+        return actualLong.compareTo(expectedLong);
     }
 
     private static int floatingEqualWithTolerance(Object actual, Object expected, double tolerance)
@@ -190,9 +190,7 @@ public class QueryResultValueComparator
         if (!(isFloatingPointValue(actual) && isFloatingPointValue(expected))) {
             return -1;
         }
-        Double actualDouble = Double.valueOf(actual.toString());
-        Double expectedDouble = Double.valueOf(expected.toString());
-        return DoubleMath.fuzzyCompare(actualDouble, expectedDouble, tolerance);
+        return DoubleMath.fuzzyCompare(getDoubleValue(actual), getDoubleValue(expected), tolerance);
     }
 
     private int singleFloatingEqual(Object actual, Object expected)
@@ -237,13 +235,24 @@ public class QueryResultValueComparator
         return -1;
     }
 
-    private boolean isIntegerValue(Object value)
+    private static boolean isIntegerValue(Object value)
     {
         return (value instanceof Long || value instanceof Integer || value instanceof Short || value instanceof Byte);
+    }
+
+    private static long getLongValue(Object object)
+    {
+        return ((Number) object).longValue();
     }
 
     private static boolean isFloatingPointValue(Object value)
     {
         return (value instanceof Float || value instanceof Double);
     }
+
+    private static double getDoubleValue(Object object)
+    {
+        return ((Number) object).doubleValue();
+    }
+
 }


### PR DESCRIPTION
Single floats (32b) have higher machine epsilon value. We should use higher tolerance while comparing single float than we compare doubles.
This patch applies different comparator for floats and for doubles.