### PR TITLE
Fix empty batch insert issue

### DIFF
--- a/tempto-core/src/main/java/com/teradata/tempto/internal/fulfillment/table/jdbc/JdbcTableManager.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/fulfillment/table/jdbc/JdbcTableManager.java
@@ -1,4 +1,5 @@
 /*
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -242,6 +243,9 @@ public class JdbcTableManager
             throws SQLException
     {
         checkNotNull(preparedStatement);
+        if (batchRows.size() == 0) {
+            return;
+        }
         int[] insertCounts = preparedStatement.executeBatch();
         for (int rowIndex = 0; rowIndex < insertCounts.length; ++rowIndex) {
             if (insertCounts[rowIndex] != 1) {


### PR DESCRIPTION
Insert into Teradata would fail when calling ps.executeBatch() on an
emtpy batch.
https://forums.teradata.com/forum/connectivity/terajdbc-13-10-00-32-error-1382-sqlstate-hy000-the-batch-is-empty. So fix this in tempto.