### PR TITLE
Add host mapping functionality

### DIFF
--- a/tempto-core/src/main/java/com/teradata/tempto/assertions/QueryAssert.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/assertions/QueryAssert.java
@@ -31,7 +31,6 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.Lists.newArrayList;

--- a/tempto-core/src/main/java/com/teradata/tempto/configuration/Configuration.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/configuration/Configuration.java
@@ -61,16 +61,16 @@ public interface Configuration
 
     /**
      * Lists configuration key prefixes of at most given length
-     *
+     * <p>
      * E.g. for configuration with keys:
      * a.b.c
      * a.d.e
      * b
-     *
+     * <p>
      * listKeyPrefixes(1) would return ["a", "b"]
-     *
+     * <p>
      * and
-     *
+     * <p>
      * listKeyPrefixes(2) would return ["a.b", "a.d", "b"]
      *
      * @param prefixesLength Max size of prefix to list

--- a/tempto-core/src/main/java/com/teradata/tempto/dns/TemptoNameServiceDescriptor.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/dns/TemptoNameServiceDescriptor.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.teradata.tempto.dns;
+
+import com.teradata.tempto.configuration.Configuration;
+import sun.net.spi.nameservice.NameService;
+import sun.net.spi.nameservice.NameServiceDescriptor;
+
+import java.util.Map;
+
+import static com.teradata.tempto.internal.configuration.TestConfigurationFactory.createTestConfiguration;
+
+public class TemptoNameServiceDescriptor
+        implements NameServiceDescriptor
+{
+
+    public static final String PROVIDER_NAME = "map_based";
+    public static final String TYPE = "dns";
+
+    public static void enableHostMapping()
+    {
+        System.setProperty("sun.net.spi.nameservice.provider.1", TYPE + "," + PROVIDER_NAME);
+        System.setProperty("sun.net.spi.nameservice.provider.2", "default");
+    }
+
+    @Override
+    public NameService createNameService()
+            throws Exception
+    {
+        Configuration configuration = createTestConfiguration();
+        Map hosts = configuration.getSubconfiguration("hosts").asMap();
+        return new MapBasedNameService(hosts);
+    }
+
+    @Override
+    public String getProviderName()
+    {
+        return PROVIDER_NAME;
+    }
+
+    @Override
+    public String getType()
+    {
+        return TYPE;
+    }
+}

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/hadoop/hdfs/WebHdfsClient.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/hadoop/hdfs/WebHdfsClient.java
@@ -22,7 +22,6 @@ import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.teradata.tempto.hadoop.hdfs.HdfsClient;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
@@ -47,7 +46,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Collections.emptyMap;

--- a/tempto-core/src/main/resources/META-INF/services/sun.net.spi.nameservice.NameServiceDescriptor
+++ b/tempto-core/src/main/resources/META-INF/services/sun.net.spi.nameservice.NameServiceDescriptor
@@ -1,0 +1,1 @@
+com.teradata.tempto.dns.TemptoNameServiceDescriptor

--- a/tempto-core/src/test/groovy/com/teradata/tempto/internal/configuration/TestConfigurationFactoryTest.groovy
+++ b/tempto-core/src/test/groovy/com/teradata/tempto/internal/configuration/TestConfigurationFactoryTest.groovy
@@ -37,6 +37,7 @@ class TestConfigurationFactoryTest
     configuration.getStringMandatory('value.local') == 'local'
     configuration.getStringMandatory('value.both') == 'local'
     configuration.getStringMandatory('value.global') == 'global'
+    configuration.getStringMandatory('value.default') == 'default_value'
 
     configuration.getStringMandatory('resolve.local') == 'local'
     configuration.getStringMandatory('resolve.both') == 'local'

--- a/tempto-core/src/test/groovy/com/teradata/tempto/internal/configuration/TestConfigurationFactoryTest.groovy
+++ b/tempto-core/src/test/groovy/com/teradata/tempto/internal/configuration/TestConfigurationFactoryTest.groovy
@@ -17,7 +17,6 @@ package com.teradata.tempto.internal.configuration
 import com.teradata.tempto.configuration.Configuration
 import spock.lang.Specification
 
-import static com.teradata.tempto.internal.configuration.TestConfigurationFactory.CLASSPATH_PROTOCOL
 import static com.teradata.tempto.internal.configuration.TestConfigurationFactory.LOCAL_TEST_CONFIGURATION_URI_KEY
 import static com.teradata.tempto.internal.configuration.TestConfigurationFactory.TEST_CONFIGURATION_URI_KEY
 
@@ -27,8 +26,8 @@ class TestConfigurationFactoryTest
 
   def 'read test configuration'() {
     setup:
-    System.setProperty(TEST_CONFIGURATION_URI_KEY, CLASSPATH_PROTOCOL + "/configuration/global-configuration-tempto.yaml");
-    System.setProperty(LOCAL_TEST_CONFIGURATION_URI_KEY, CLASSPATH_PROTOCOL + "/configuration/local-configuration-tempto.yaml");
+    System.setProperty(TEST_CONFIGURATION_URI_KEY, "/configuration/global-configuration-tempto.yaml");
+    System.setProperty(LOCAL_TEST_CONFIGURATION_URI_KEY, "/configuration/local-configuration-tempto.yaml");
 
     when:
     Configuration configuration = TestConfigurationFactory.createTestConfiguration()

--- a/tempto-core/src/test/groovy/com/teradata/tempto/internal/query/JdbcQueryExecutorTest.groovy
+++ b/tempto-core/src/test/groovy/com/teradata/tempto/internal/query/JdbcQueryExecutorTest.groovy
@@ -28,6 +28,7 @@ import java.sql.Connection
 
 import static com.teradata.tempto.assertions.QueryAssert.Row.row
 import static com.teradata.tempto.assertions.QueryAssert.assertThat
+import static com.teradata.tempto.internal.configuration.TestConfigurationFactory.TEST_CONFIGURATION_URI_KEY
 import static com.teradata.tempto.internal.query.JdbcUtils.connection
 import static com.teradata.tempto.internal.query.JdbcUtils.registerDriver
 import static java.sql.JDBCType.INTEGER
@@ -51,7 +52,7 @@ class JdbcQueryExecutorTest
 
   def setupSpec()
   {
-    System.setProperty(TestConfigurationFactory.TEST_CONFIGURATION_URI_KEY, TestConfigurationFactory.CLASSPATH_PROTOCOL + "/configuration/global-configuration-tempto.yaml");
+    System.setProperty(TEST_CONFIGURATION_URI_KEY, "/configuration/global-configuration-tempto.yaml");
     registerDriver(JDBC_STATE)
   }
 

--- a/tempto-core/src/test/groovy/com/teradata/tempto/sql/view/ContextDslTest.groovy
+++ b/tempto-core/src/test/groovy/com/teradata/tempto/sql/view/ContextDslTest.groovy
@@ -21,6 +21,7 @@ import com.teradata.tempto.query.QueryExecutor
 import com.teradata.tempto.query.QueryResult
 import spock.lang.Specification
 
+import static com.teradata.tempto.internal.configuration.TestConfigurationFactory.TEST_CONFIGURATION_URI_KEY
 import static com.teradata.tempto.query.QueryType.UPDATE
 
 class ContextDslTest
@@ -28,7 +29,7 @@ class ContextDslTest
 {
   def setupSpec()
   {
-    System.setProperty(TestConfigurationFactory.TEST_CONFIGURATION_URI_KEY, TestConfigurationFactory.CLASSPATH_PROTOCOL + "/configuration/global-configuration-tempto.yaml");
+    System.setProperty(TEST_CONFIGURATION_URI_KEY, "/configuration/global-configuration-tempto.yaml");
   }
 
   def 'executeWithView'()

--- a/tempto-core/src/test/resources/configuration/global-configuration-tempto.yaml
+++ b/tempto-core/src/test/resources/configuration/global-configuration-tempto.yaml
@@ -1,4 +1,5 @@
 value:
+  default: ${not.exisiting.key:-default_value}
   both: global
   global: global
 

--- a/tempto-examples/bin/init.sh
+++ b/tempto-examples/bin/init.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+docker run --name tempto-examples-psql -p 15432:5432 -e POSTGRES_USER=blah -e POSTGRES_PASSWORD=blah  -d postgres
+docker run --name tempto-examples-psql2 -p 15433:5432 -e POSTGRES_USER=blah -e POSTGRES_PASSWORD=blah  -d postgres
+#presto-devenv presto build-image

--- a/tempto-examples/bin/run.sh
+++ b/tempto-examples/bin/run.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -ex
+
+function wait_for() {
+  echo "waiting for $*"
+  for i in $(seq 10); do
+    if $* > /dev/null 2>&1; then
+      return
+    fi
+    echo ...
+    sleep 5
+  done
+  echo "$* - did not succeeded within a time limit"
+  exit 1
+}
+
+function get_docker_host_ip() {
+  if [ x$DOCKER_HOST == "x" ]; then
+    echo localhost
+  else 
+    echo $DOCKER_HOST | sed 's@.*/\(.*\):.*@\1@'
+  fi
+}
+
+cd $(dirname $(readlink -f $0))
+
+presto-devenv hadoop start
+presto-devenv presto start
+wait_for presto-devenv status
+docker start tempto-examples-psql
+docker start tempto-examples-psql2
+
+export IDENTITY=~/.vagrant.d/insecure_private_key
+export DOCKER_MACHINE=$(get_docker_host_ip)
+java -jar ../build/libs/tempto-examples-all.jar $*
+

--- a/tempto-examples/src/main/java/com/teradata/tempto/examples/HostNameMappingTest.java
+++ b/tempto-examples/src/main/java/com/teradata/tempto/examples/HostNameMappingTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.teradata.tempto.examples;
+
+import com.teradata.tempto.ProductTest;
+import org.testng.annotations.Test;
+
+import java.net.Inet4Address;
+import java.net.UnknownHostException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HostNameMappingTest
+        extends ProductTest
+{
+    @Test(groups = "dns")
+    public void localhostAlias()
+            throws UnknownHostException
+    {
+        assertThat(Inet4Address.getAllByName("localhost_alias")).isEqualTo(Inet4Address.getAllByName("localhost"));
+        assertThat(Inet4Address.getAllByName("teradata_alias")).isEqualTo(Inet4Address.getAllByName("teradata.com"));
+    }
+}

--- a/tempto-examples/src/main/java/com/teradata/tempto/examples/TemptoExamples.java
+++ b/tempto-examples/src/main/java/com/teradata/tempto/examples/TemptoExamples.java
@@ -17,6 +17,8 @@ package com.teradata.tempto.examples;
 import com.teradata.tempto.runner.TemptoRunner;
 import com.teradata.tempto.runner.TemptoRunnerCommandLineParser;
 
+import static com.teradata.tempto.internal.configuration.TestConfigurationFactory.DEFAULT_TEST_CONFIGURATION_LOCATION;
+
 public class TemptoExamples
 {
 
@@ -25,7 +27,7 @@ public class TemptoExamples
         TemptoRunnerCommandLineParser parser = TemptoRunnerCommandLineParser
                 .builder("tempto examples")
                 .setTestsPackage("com.teradata.tempto.examples", false)
-                .setConfigFile("classpath:/tempto-configuration.yaml", false)
+                .setConfigFile(DEFAULT_TEST_CONFIGURATION_LOCATION, false)
                 .build();
         TemptoRunner.runTempto(parser, args);
     }

--- a/tempto-examples/src/main/resources/tempto-configuration.yaml
+++ b/tempto-examples/src/main/resources/tempto-configuration.yaml
@@ -1,7 +1,7 @@
 hdfs:
   username: hdfs
   webhdfs:
-    host: ${HADOOP_MASTER:-hadoop-master}
+    host: ${DOCKER_MACHINE}
     port: 50070
 
 databases:
@@ -10,7 +10,7 @@ databases:
 
   hive:
     jdbc_driver_class: org.apache.hive.jdbc.HiveDriver
-    jdbc_url: jdbc:hive2://${hdfs.webhdfs.host}:10000
+    jdbc_url: jdbc:hive2://${DOCKER_MACHINE}:10000
     jdbc_user: hdfs
     jdbc_password: na
     jdbc_pooling: false
@@ -18,7 +18,7 @@ databases:
 
   presto:
     jdbc_driver_class: com.facebook.presto.jdbc.PrestoDriver
-    jdbc_url: jdbc:presto://${PRESTO_MASTER:-presto-master}:8080/hive/default
+    jdbc_url: jdbc:presto://${DOCKER_MACHINE}:8080/hive/default
     jdbc_user: hdfs
     jdbc_password: na
     jdbc_pooling: false

--- a/tempto-examples/src/main/resources/tempto-configuration.yaml
+++ b/tempto-examples/src/main/resources/tempto-configuration.yaml
@@ -1,7 +1,7 @@
 hdfs:
   username: hdfs
   webhdfs:
-    host: hadoop-master
+    host: ${HADOOP_MASTER:-hadoop-master}
     port: 50070
 
 databases:
@@ -10,7 +10,7 @@ databases:
 
   hive:
     jdbc_driver_class: org.apache.hive.jdbc.HiveDriver
-    jdbc_url: jdbc:hive2://hadoop-master:10000
+    jdbc_url: jdbc:hive2://${hdfs.webhdfs.host}:10000
     jdbc_user: hdfs
     jdbc_password: na
     jdbc_pooling: false
@@ -18,7 +18,7 @@ databases:
 
   presto:
     jdbc_driver_class: com.facebook.presto.jdbc.PrestoDriver
-    jdbc_url: jdbc:presto://presto-master:8080/hive/default
+    jdbc_url: jdbc:presto://${PRESTO_MASTER:-presto-master}:8080/hive/default
     jdbc_user: hdfs
     jdbc_password: na
     jdbc_pooling: false

--- a/tempto-examples/src/main/resources/tempto-configuration.yaml
+++ b/tempto-examples/src/main/resources/tempto-configuration.yaml
@@ -57,6 +57,11 @@ ssh:
       port: 22
       user: ${USER_B}
 
+hosts:
+  localhost_alias: localhost
+  teradata_alias: teradata.com
+  hadoop-master: ${DOCKER_MACHINE}
+
 list:
   string:
     - ala

--- a/tempto-runner/src/main/java/com/teradata/tempto/runner/TemptoRunner.java
+++ b/tempto-runner/src/main/java/com/teradata/tempto/runner/TemptoRunner.java
@@ -15,6 +15,7 @@
 package com.teradata.tempto.runner;
 
 import com.google.common.base.Joiner;
+import com.teradata.tempto.dns.TemptoNameServiceDescriptor;
 import com.teradata.tempto.internal.listeners.TestNameGroupNameMethodSelector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,6 +37,10 @@ import static java.util.Collections.singletonList;
 
 public class TemptoRunner
 {
+    static {
+        TemptoNameServiceDescriptor.enableHostMapping();
+    }
+
     private static final Logger LOG = LoggerFactory.getLogger(TemptoRunner.class);
     private static final int METHOD_SELECTOR_PRIORITY = 20;
     private static final String METHOD_SELECTOR_CLASS_NAME = TestNameGroupNameMethodSelector.class.getName();

--- a/tempto-runner/src/main/java/com/teradata/tempto/runner/TemptoRunnerCommandLineParser.java
+++ b/tempto-runner/src/main/java/com/teradata/tempto/runner/TemptoRunnerCommandLineParser.java
@@ -16,6 +16,7 @@ package com.teradata.tempto.runner;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.teradata.tempto.internal.configuration.TestConfigurationFactory;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -170,8 +171,8 @@ public class TemptoRunnerCommandLineParser
             addOption(TESTS);
             addOption(HELP);
             setReportDir("./test-reports", true);
-            setConfigFile("classpath:/tempto-configuration.yaml", true);
-            setConfigLocalFile("classpath:/tempto-configuration-local.yaml", true);
+            setConfigFile(TestConfigurationFactory.DEFAULT_TEST_CONFIGURATION_LOCATION, true);
+            setConfigLocalFile(TestConfigurationFactory.DEFAULT_LOCAL_TEST_CONFIGURATION_LOCATION, true);
         }
 
         public Builder addOption(Option option)


### PR DESCRIPTION
Add host mapping functionality

When doing test with hadoop cluster it may happen that hadoop ports are
forwarded to different machine. In such case namenode may return address
of datanode which is unresolveable from localhost. In such case host
mapping can be helpful.

See HostNameMappingTest and tempto-configuration files for usage.

Test Plan: running tempto examples

Reviewers: losipiuk
