### PR TITLE
Make error message about missing local configuration more neutral

### DIFF
--- a/tempto-core/src/main/java/com/teradata/tempto/internal/configuration/TestConfigurationFactory.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/configuration/TestConfigurationFactory.java
@@ -60,7 +60,7 @@ public class TestConfigurationFactory
             return parseConfiguration(testConfigurationStream);
         }
         else {
-            LOGGER.warn("Unable to find local configuration: {}", configurationLocation);
+            LOGGER.info("Default configuration is being used. Local configuration is absent: {}", configurationLocation);
             return emptyConfiguration();
         }
     }


### PR DESCRIPTION
It is possible to run Tempto only with basic configuration, that is
implemented and packaged into the tests runnable.
We do so in Presto when running product tests from IDE.
It is not that easy to specify local configuration for each test run profile
automatically created by IDE. So we are setting reasonable defaults in default
tempto configuration and letting user to run product tests without local
configuration specified. But the message `WARN: Unable to find local configuration:`
can make user worry that he did something wrong. Instead of displaying such wary
message we decided to display something more neutral.