### PR TITLE
Add owner function to WebHdfsClient

### DIFF
--- a/tempto-core/src/main/java/com/teradata/tempto/hadoop/hdfs/HdfsClient.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/hadoop/hdfs/HdfsClient.java
@@ -78,4 +78,6 @@ public interface HdfsClient
     long getLength(String path);
 
     boolean exist(String path);
+
+    String getOwner(String path);
 }

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/hadoop/hdfs/WebHdfsClient.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/hadoop/hdfs/WebHdfsClient.java
@@ -183,9 +183,7 @@ public class WebHdfsClient
         }
     }
 
-    @Override
-    @SuppressWarnings("unchecked")
-    public long getLength(String path)
+    private Object getAttributeValue(String path, String attribute)
     {
         HttpGet readRequest = new HttpGet(buildUri(path, "GETFILESTATUS", emptyMap()));
         try (CloseableHttpResponse response = httpRequestsExecutor.execute(readRequest)) {
@@ -194,11 +192,25 @@ public class WebHdfsClient
                 throw invalidStatusException("GETFILESTATUS", path, readRequest, response);
             }
             Map<String, Object> responseObject = deserializeJsonResponse(response);
-            return ((Number) ((Map<String, Object>) responseObject.get("FileStatus")).get("length")).longValue();
+            return ((Map<String, Object>) responseObject.get("FileStatus")).get(attribute);
         }
         catch (IOException e) {
             throw new RuntimeException("Could not get file status: " + path + " , user: " + username, e);
         }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public long getLength(String path)
+    {
+        return ((Number) getAttributeValue (path, "length")).longValue();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public String getOwner(String path)
+    {
+        return ((String) getAttributeValue (path, "owner"));
     }
 
     @Override


### PR DESCRIPTION
Add a function to get the owner of a file/directory on hdfs.
This is required for running kerberos/impersonation product-tests.