### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/tempto-core/src/main/java/com/teradata/tempto/ProductTest.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/ProductTest.java
@@ -24,5 +24,7 @@ import org.testng.annotations.Listeners;
 @Listeners({RequirementsExpanderInterceptor.class, TestInitializationListener.class, ProgressLoggingListener.class})
 public class ProductTest
 {
+    private ProductTest() {}
+
     protected static final Logger LOGGER = LoggerFactory.getLogger(ProductTest.class);
 }

--- a/tempto-core/src/main/java/com/teradata/tempto/fulfillment/table/TableRequirements.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/fulfillment/table/TableRequirements.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 
 public class TableRequirements
 {
+    private TableRequirements() {}
 
     /**
      * Requirement for mutable table.

--- a/tempto-core/src/main/java/com/teradata/tempto/fulfillment/table/hive/tpch/TpchTableDefinitions.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/fulfillment/table/hive/tpch/TpchTableDefinitions.java
@@ -159,4 +159,6 @@ public class TpchTableDefinitions
                             "LOCATION '%LOCATION%'")
                     .setDataSource(new TpchDataSource(TpchTable.LINE_ITEM, 1.0))
                     .build();
+
+    private TpchTableDefinitions() {}
 }

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/DataProviders.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/DataProviders.java
@@ -29,6 +29,8 @@ import static java.util.Arrays.asList;
 public class DataProviders
 {
 
+    private DataProviders() {}
+
     /**
      * Obtains list of parameter sets for test method based on defined data provider.
      * If no data provider is defined then {@link Optional#empty()} is returned.

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/RequirementFulfillerPriorityHelper.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/RequirementFulfillerPriorityHelper.java
@@ -18,6 +18,8 @@ import com.teradata.tempto.fulfillment.RequirementFulfiller;
 
 public class RequirementFulfillerPriorityHelper
 {
+    private RequirementFulfillerPriorityHelper() {}
+
     public static int getPriority(Class<? extends RequirementFulfiller> c)
     {
         if (c.getAnnotation(RequirementFulfiller.AutoSuiteLevelFulfiller.class) != null) {

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/configuration/TestConfigurationFactory.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/configuration/TestConfigurationFactory.java
@@ -35,6 +35,8 @@ public class TestConfigurationFactory
     public static final String DEFAULT_TEST_CONFIGURATION_LOCATION = "tempto-configuration.yaml";
     public static final String DEFAULT_LOCAL_TEST_CONFIGURATION_LOCATION = "tempto-configuration-local.yaml";
 
+    private TestConfigurationFactory() {}
+
     public static Configuration createTestConfiguration()
     {
         Configuration configuration = new HierarchicalConfiguration(readTestConfiguration(), readLocalConfiguration());

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/logging/LoggingMdcHelper.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/logging/LoggingMdcHelper.java
@@ -23,6 +23,8 @@ public class LoggingMdcHelper
     private static final String MDC_TEST_ID_KEY = "test_id";
     private static final TestMetadataReader testMetadataReader = new TestMetadataReader();
 
+    private LoggingMdcHelper() {}
+
     public static void setupLoggingMdcForTest(ITestResult testCase) {
         TestMetadata testMetadata = testMetadataReader.readTestMetadata(testCase);
         String testId = testMetadata.testName;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava