### PR TITLE
Multiple code improvements - squid:S1213, squid:S1149, squid:S2275, squid:MissingDeprecatedCheck, squid:RedundantThrowsDeclarationCheck, squid:S2259, squid:LowerCaseLongSuffixCheck

### DIFF
--- a/tempto-core/src/main/java/com/teradata/tempto/Requirements.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/Requirements.java
@@ -30,6 +30,10 @@ import static java.util.Arrays.asList;
  */
 public final class Requirements
 {
+    private Requirements()
+    {
+    }
+
     public static CompositeRequirement compose(Requirement... requirements)
     {
         return compose(asList(requirements));
@@ -123,9 +127,5 @@ public final class Requirements
             }
             return newExpandedRequirementsSets;
         }
-    }
-
-    private Requirements()
-    {
     }
 }

--- a/tempto-core/src/main/java/com/teradata/tempto/assertions/QueryAssert.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/assertions/QueryAssert.java
@@ -30,6 +30,7 @@ import java.text.NumberFormat;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -100,7 +101,7 @@ public class QueryAssert
             containsExactly(rows);
         }
 
-        if (!sqlResultDescriptor.isIgnoreExcessRows()) {
+        if (!sqlResultDescriptor.isIgnoreExcessRows() && Objects.nonNull(rows)) {
             hasRowsCount(rows.size());
         }
 
@@ -402,7 +403,7 @@ public class QueryAssert
             for (String expectedErrorMessage : expectedErrorMessages) {
                 if (!exceptionMessage.contains(expectedErrorMessage)) {
                     throw new AssertionError(format(
-                            "Query failed with unexpected error message: '%s' \n Expected error message was '%s'",
+                            "Query failed with unexpected error message: '%s' %n Expected error message was '%s'",
                             exceptionMessage,
                             expectedErrorMessage
                     ));

--- a/tempto-core/src/main/java/com/teradata/tempto/configuration/KeyUtils.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/configuration/KeyUtils.java
@@ -24,11 +24,11 @@ import static java.util.Arrays.asList;
 
 public final class KeyUtils
 {
-    private KeyUtils() {}
-
     private static final char KEY_SEPARATOR = '.';
     private static final Splitter KEY_SPLITTER = Splitter.on(KEY_SEPARATOR);
     private static final Joiner KEY_JOINER = Joiner.on(KEY_SEPARATOR).skipNulls();
+
+    private KeyUtils() {}
 
     public static List<String> splitKey(String key)
     {

--- a/tempto-core/src/main/java/com/teradata/tempto/context/ContextDsl.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/context/ContextDsl.java
@@ -21,6 +21,10 @@ package com.teradata.tempto.context;
 public final class ContextDsl
 {
 
+    private ContextDsl()
+    {
+    }
+
     public static <T> void executeWith(ContextProvider<T> provider, ContextRunnable<T> runnable)
     {
         T context = provider.setup();
@@ -31,9 +35,5 @@ public final class ContextDsl
         finally {
             provider.cleanup(context);
         }
-    }
-
-    private ContextDsl()
-    {
     }
 }

--- a/tempto-core/src/main/java/com/teradata/tempto/context/TestContextDsl.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/context/TestContextDsl.java
@@ -21,6 +21,10 @@ import static com.teradata.tempto.context.ThreadLocalTestContextHolder.testConte
 
 public final class TestContextDsl
 {
+    private TestContextDsl()
+    {
+    }
+
     public static IndexedRunnable withChildTestContext(IndexedRunnable runnable)
     {
         return (int threadIndex) -> {
@@ -53,9 +57,5 @@ public final class TestContextDsl
         finally {
             popTestContext();
         }
-    }
-
-    private TestContextDsl()
-    {
     }
 }

--- a/tempto-core/src/main/java/com/teradata/tempto/context/ThreadLocalTestContextHolder.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/context/ThreadLocalTestContextHolder.java
@@ -48,6 +48,8 @@ public final class ThreadLocalTestContextHolder
         }
     };
 
+    private ThreadLocalTestContextHolder() {}
+
     public static TestContext testContext()
     {
         assertTestContextSet();
@@ -110,6 +112,4 @@ public final class ThreadLocalTestContextHolder
             testContextStackThreadLocal.set(new TestContextStack<>());
         }
     }
-
-    private ThreadLocalTestContextHolder() {}
 }

--- a/tempto-core/src/main/java/com/teradata/tempto/fulfillment/table/ImmutableTablesState.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/fulfillment/table/ImmutableTablesState.java
@@ -22,13 +22,13 @@ public class ImmutableTablesState
         extends TablesState
 {
 
-    public static ImmutableTablesState immutableTablesState()
-    {
-        return testContext().getDependency(ImmutableTablesState.class);
-    }
-
     public ImmutableTablesState(List<TableInstance> tables)
     {
         super(tables, "immutable table");
+    }
+
+    public static ImmutableTablesState immutableTablesState()
+    {
+        return testContext().getDependency(ImmutableTablesState.class);
     }
 }

--- a/tempto-core/src/main/java/com/teradata/tempto/fulfillment/table/MutableTablesState.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/fulfillment/table/MutableTablesState.java
@@ -22,13 +22,13 @@ public class MutableTablesState
         extends TablesState
 {
 
-    public static MutableTablesState mutableTablesState()
-    {
-        return testContext().getDependency(MutableTablesState.class);
-    }
-
     public MutableTablesState(List<TableInstance> tables)
     {
         super(tables, "mutable table");
+    }
+
+    public static MutableTablesState mutableTablesState()
+    {
+        return testContext().getDependency(MutableTablesState.class);
     }
 }

--- a/tempto-core/src/main/java/com/teradata/tempto/fulfillment/table/TableDefinitionsRepository.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/fulfillment/table/TableDefinitionsRepository.java
@@ -53,6 +53,17 @@ public class TableDefinitionsRepository
 
     private static final TableDefinitionsRepository TABLE_DEFINITIONS_REPOSITORY;
 
+    private final Map<String, TableDefinition> tableDefinitions = new MapMaker().makeMap();
+
+    public TableDefinitionsRepository()
+    {
+    }
+
+    public TableDefinitionsRepository(Collection<TableDefinition> tableDefinitions)
+    {
+        tableDefinitions.stream().forEach(this::register);
+    }
+
     static {
         // ExceptionInInitializerError is not always appropriately logged, lets log exceptions explicitly here
         try {
@@ -84,17 +95,6 @@ public class TableDefinitionsRepository
     public static TableDefinitionsRepository tableDefinitionsRepository()
     {
         return TABLE_DEFINITIONS_REPOSITORY;
-    }
-
-    private final Map<String, TableDefinition> tableDefinitions = new MapMaker().makeMap();
-
-    public TableDefinitionsRepository()
-    {
-    }
-
-    public TableDefinitionsRepository(Collection<TableDefinition> tableDefinitions)
-    {
-        tableDefinitions.stream().forEach(this::register);
     }
 
     public <T extends TableDefinition> T register(T tableDefinition)

--- a/tempto-core/src/main/java/com/teradata/tempto/fulfillment/table/TableHandle.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/fulfillment/table/TableHandle.java
@@ -25,6 +25,25 @@ import static java.util.Objects.requireNonNull;
 
 public class TableHandle
 {
+    private final Optional<String> database;
+
+    private final Optional<String> schema;
+    private final String name;
+    private final boolean requireNoSchema;
+
+    private TableHandle(Optional<String> database, Optional<String> schema, String name) {
+        this(database, schema, name, false);
+    }
+
+    private TableHandle(Optional<String> database, Optional<String> schema, String name, boolean requireNoSchema)
+    {
+        checkArgument(!(requireNoSchema && schema.isPresent()), "Schema given while required no schema.");
+        this.database = requireNonNull(database, "database is null");
+        this.schema = requireNonNull(schema, "schema is null");
+        this.name = requireNonNull(name, "name is null");
+        this.requireNoSchema = requireNoSchema;
+    }
+
     public static TableHandle tableHandle(String name)
     {
         return new TableHandle(Optional.empty(), Optional.empty(), name);
@@ -43,25 +62,6 @@ public class TableHandle
         else {
             return tableHandle(value);
         }
-    }
-
-    private final Optional<String> database;
-
-    private final Optional<String> schema;
-    private final String name;
-    private final boolean requireNoSchema;
-
-    private TableHandle(Optional<String> database, Optional<String> schema, String name) {
-        this(database, schema, name, false);
-    }
-
-    private TableHandle(Optional<String> database, Optional<String> schema, String name, boolean requireNoSchema)
-    {
-        checkArgument(!(requireNoSchema && schema.isPresent()), "Schema given while required no schema.");
-        this.database = requireNonNull(database, "database is null");
-        this.schema = requireNonNull(schema, "schema is null");
-        this.name = requireNonNull(name, "name is null");
-        this.requireNoSchema = requireNoSchema;
     }
 
     public TableHandle withName(String name)

--- a/tempto-core/src/main/java/com/teradata/tempto/fulfillment/table/jdbc/JdbcTableDefinition.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/fulfillment/table/jdbc/JdbcTableDefinition.java
@@ -26,16 +26,6 @@ import static org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCod
 public class JdbcTableDefinition
         extends TableDefinition
 {
-    public static JdbcTableDefinition jdbcTableDefinition(String name, String createTableDDLTemplate, JdbcTableDataSource dataSource)
-    {
-        return jdbcTableDefinition(tableHandle(name), createTableDDLTemplate, dataSource);
-    }
-
-    public static JdbcTableDefinition jdbcTableDefinition(TableHandle tableHandle, String createTableDDLTemplate, JdbcTableDataSource dataSource)
-    {
-        return new JdbcTableDefinition(tableHandle, createTableDDLTemplate, dataSource);
-    }
-
     private static final String NAME_MARKER = "%NAME%";
     private final JdbcTableDataSource dataSource;
 
@@ -48,6 +38,16 @@ public class JdbcTableDefinition
         this.dataSource = checkNotNull(dataSource, "dataSource is null");
         this.createTableDDLTemplate = checkNotNull(createTableDDLTemplate, "createTableDDLTemplate is null");
         checkArgument(createTableDDLTemplate.contains(NAME_MARKER), "Create table DDL must contain %NAME% placeholder");
+    }
+
+    public static JdbcTableDefinition jdbcTableDefinition(String name, String createTableDDLTemplate, JdbcTableDataSource dataSource)
+    {
+        return jdbcTableDefinition(tableHandle(name), createTableDDLTemplate, dataSource);
+    }
+
+    public static JdbcTableDefinition jdbcTableDefinition(TableHandle tableHandle, String createTableDDLTemplate, JdbcTableDataSource dataSource)
+    {
+        return new JdbcTableDefinition(tableHandle, createTableDDLTemplate, dataSource);
     }
 
     public JdbcTableDataSource getDataSource()

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/ReflectionHelper.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/ReflectionHelper.java
@@ -61,6 +61,10 @@ public final class ReflectionHelper
                 }
             });
 
+    private ReflectionHelper()
+    {
+    }
+
     public static <T> T getStaticFieldValue(Field field)
     {
         try {
@@ -111,9 +115,5 @@ public final class ReflectionHelper
         catch (InstantiationException | IllegalAccessException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private ReflectionHelper()
-    {
     }
 }

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/RequirementFulfillerPriorityHelper.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/RequirementFulfillerPriorityHelper.java
@@ -28,7 +28,7 @@ public class RequirementFulfillerPriorityHelper
         }
         else {
             throw new RuntimeException(
-                    String.format("Class '%s' is not annotated with '%' or '%s'.",
+                    String.format("Class '%s' is not annotated with '%s' or '%s'.",
                             c.getName(), RequirementFulfiller.AutoSuiteLevelFulfiller.class.getName(), RequirementFulfiller.AutoTestLevelFulfiller.class.getName()));
         }
     }

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/configuration/EmptyConfiguration.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/configuration/EmptyConfiguration.java
@@ -25,11 +25,11 @@ public class EmptyConfiguration extends AbstractConfiguration
 
     private static final EmptyConfiguration INSTANCE = new EmptyConfiguration();
 
+    private EmptyConfiguration() {}
+
     public static Configuration emptyConfiguration() {
         return INSTANCE;
     }
-
-    private EmptyConfiguration() {}
 
     @Override
     public Optional<Object> get(String key)

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/context/TestContextStack.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/context/TestContextStack.java
@@ -16,13 +16,15 @@ package com.teradata.tempto.internal.context;
 
 import com.teradata.tempto.context.TestContext;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.Iterator;
 import java.util.Stack;
 
 public class TestContextStack<C extends TestContext>
         implements Iterable<C>
 {
-    private final Stack<C> testContextStack = new Stack<>();
+    private final Deque<C> testContextStack = new ArrayDeque<>();
 
     public void push(C testContext)
     {
@@ -46,7 +48,7 @@ public class TestContextStack<C extends TestContext>
 
     public boolean empty()
     {
-        return testContextStack.empty();
+        return testContextStack.isEmpty();
     }
 
     @Override

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/convention/ConventionTestsUtils.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/convention/ConventionTestsUtils.java
@@ -52,6 +52,10 @@ public final class ConventionTestsUtils
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ConventionTestsUtils.class);
 
+    private ConventionTestsUtils()
+    {
+    }
+
     public static Optional<Path> getConventionsTestsPath(String child)
     {
         try {
@@ -142,9 +146,5 @@ public final class ConventionTestsUtils
         catch (IOException e) {
             throw new RuntimeException("Could not process URI: " + uri, e);
         }
-    }
-
-    private ConventionTestsUtils()
-    {
     }
 }

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/convention/ProcessUtils.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/convention/ProcessUtils.java
@@ -21,6 +21,10 @@ public final class ProcessUtils
 {
     private static final int SUCCESS_EXIT_CODE = 0;
 
+    private ProcessUtils()
+    {
+    }
+
     public static void execute(String... cmdarray)
     {
         checkState(cmdarray.length > 0);
@@ -33,9 +37,5 @@ public final class ProcessUtils
         catch (IOException | InterruptedException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private ProcessUtils()
-    {
     }
 }

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/convention/SqlResultDescriptor.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/convention/SqlResultDescriptor.java
@@ -52,6 +52,17 @@ public class SqlResultDescriptor
 
     private final Optional<List<JDBCType>> expectedTypes;
 
+    public SqlResultDescriptor(SectionParsingResult sqlSectionParsingResult)
+    {
+        this(sqlSectionParsingResult, newHashMap());
+    }
+
+    public SqlResultDescriptor(SectionParsingResult sqlSectionParsingResult, Map<String, String> baseProperties)
+    {
+        super(sqlSectionParsingResult, baseProperties);
+        this.expectedTypes = parseExpectedTypes(sqlSectionParsingResult);
+    }
+
     public static SqlResultDescriptor sqlResultDescriptorForResource(String resourceName)
     {
         try {
@@ -71,17 +82,6 @@ public class SqlResultDescriptor
             throws IOException
     {
         return new SqlResultDescriptor(getOnlyElement(new AnnotatedFileParser().parseFile(inputStream)));
-    }
-
-    public SqlResultDescriptor(SectionParsingResult sqlSectionParsingResult)
-    {
-        this(sqlSectionParsingResult, newHashMap());
-    }
-
-    public SqlResultDescriptor(SectionParsingResult sqlSectionParsingResult, Map<String, String> baseProperties)
-    {
-        super(sqlSectionParsingResult, baseProperties);
-        this.expectedTypes = parseExpectedTypes(sqlSectionParsingResult);
     }
 
     private Optional<List<JDBCType>> parseExpectedTypes(SectionParsingResult sqlFileSectionParsingResult)

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/convention/tabledefinitions/ConventionTableDefinitionDescriptor.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/convention/tabledefinitions/ConventionTableDefinitionDescriptor.java
@@ -37,18 +37,18 @@ class ConventionTableDefinitionDescriptor
         private final TableType tableType;
         private final Optional<String> schema;
 
-        public static ParsedDDLFile forPath(Path dataFile)
-        {
-            List<SectionParsingResult> sectionParsingResults = new AnnotatedFileParser().parseFile(dataFile);
-            SectionParsingResult onlySection = getOnlyElement(sectionParsingResults);
-            return new ParsedDDLFile(onlySection);
-        }
-
         private ParsedDDLFile(SectionParsingResult sqlSectionParsingResult)
         {
             super(sqlSectionParsingResult);
             tableType = getTableTypeFromProperties();
             schema = getPropertyValue("schema");
+        }
+
+        public static ParsedDDLFile forPath(Path dataFile)
+        {
+            List<SectionParsingResult> sectionParsingResults = new AnnotatedFileParser().parseFile(dataFile);
+            SectionParsingResult onlySection = getOnlyElement(sectionParsingResults);
+            return new ParsedDDLFile(onlySection);
         }
 
         private TableType getTableTypeFromProperties()

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/convention/tabledefinitions/JdbcDataFileDescriptor.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/convention/tabledefinitions/JdbcDataFileDescriptor.java
@@ -44,15 +44,15 @@ public class JdbcDataFileDescriptor
 
     private final List<JDBCType> columnTypes;
 
-    public static JdbcDataFileDescriptor sqlResultDescriptorFor(Path file)
-    {
-        return new JdbcDataFileDescriptor(getOnlyElement(new AnnotatedFileParser().parseFile(file)));
-    }
-
     public JdbcDataFileDescriptor(SectionParsingResult sqlSectionParsingResult)
     {
         super(sqlSectionParsingResult);
         this.columnTypes = parseColumnTypes(sqlSectionParsingResult);
+    }
+
+    public static JdbcDataFileDescriptor sqlResultDescriptorFor(Path file)
+    {
+        return new JdbcDataFileDescriptor(getOnlyElement(new AnnotatedFileParser().parseFile(file)));
     }
 
     private List<JDBCType> parseColumnTypes(SectionParsingResult sqlFileSectionParsingResult)

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/initialization/DelegateTestNGMethod.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/initialization/DelegateTestNGMethod.java
@@ -54,6 +54,11 @@ public abstract class DelegateTestNGMethod
         delegate.setTestClass(cls);
     }
 
+    /**
+     * @deprecated Kept for backwards compatibility
+     *
+     * @return
+     */
     @Override
     @Deprecated
     public Method getMethod()
@@ -67,6 +72,11 @@ public abstract class DelegateTestNGMethod
         return delegate.getMethodName();
     }
 
+    /**
+     * @deprecated Kept for backwards compatibility
+     *
+     * @return
+     */
     @Override
     @Deprecated
     public Object[] getInstances()

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/initialization/TestInitializationListener.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/initialization/TestInitializationListener.java
@@ -107,6 +107,20 @@ public class TestInitializationListener
                 createTestConfiguration());
     }
 
+    public TestInitializationListener(
+            List<? extends SuiteModuleProvider> suiteModuleProviders,
+            List<? extends TestMethodModuleProvider> testMethodModuleProviders,
+            List<Class<? extends RequirementFulfiller>> suiteLevelFulfillers,
+            List<Class<? extends RequirementFulfiller>> testMethodLevelFulfillers,
+            Configuration configuration)
+    {
+        this.suiteModuleProviders = suiteModuleProviders;
+        this.testMethodModuleProviders = testMethodModuleProviders;
+        this.suiteLevelFulfillers = suiteLevelFulfillers;
+        this.testMethodLevelFulfillers = testMethodLevelFulfillers;
+        this.configuration = configuration;
+    }
+
     private static List<Class<? extends RequirementFulfiller>> getTestMethodLevelFulfillers()
     {
         return collectFulfillers(BUILTIN_TEST_METHOD_LEVEL_FULFILLERS, AutoTestLevelFulfiller.class);
@@ -154,20 +168,6 @@ public class TestInitializationListener
     public static List<? extends TestMethodModuleProvider> getTestMethodModuleProviders()
     {
         return instantiate(getAnnotatedSubTypesOf(TestMethodModuleProvider.class, AutoModuleProvider.class));
-    }
-
-    public TestInitializationListener(
-            List<? extends SuiteModuleProvider> suiteModuleProviders,
-            List<? extends TestMethodModuleProvider> testMethodModuleProviders,
-            List<Class<? extends RequirementFulfiller>> suiteLevelFulfillers,
-            List<Class<? extends RequirementFulfiller>> testMethodLevelFulfillers,
-            Configuration configuration)
-    {
-        this.suiteModuleProviders = suiteModuleProviders;
-        this.testMethodModuleProviders = testMethodModuleProviders;
-        this.suiteLevelFulfillers = suiteLevelFulfillers;
-        this.testMethodLevelFulfillers = testMethodLevelFulfillers;
-        this.configuration = configuration;
     }
 
     @Override

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/query/JdbcUtils.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/query/JdbcUtils.java
@@ -31,6 +31,10 @@ import static java.sql.DriverManager.getConnection;
 
 public final class JdbcUtils
 {
+    private JdbcUtils()
+    {
+    }
+
     public static void registerDriver(JdbcConnectivityParamsState jdbcParamsState)
     {
         try {
@@ -109,9 +113,5 @@ public final class JdbcUtils
                 jdbcParamsState.url,
                 jdbcParamsState.user,
                 jdbcParamsState.password);
-    }
-
-    private JdbcUtils()
-    {
     }
 }

--- a/tempto-core/src/main/java/com/teradata/tempto/process/CliProcess.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/process/CliProcess.java
@@ -66,8 +66,8 @@ public interface CliProcess extends Closeable
      * @throws TimeoutRuntimeException
      */
     void waitForWithTimeoutAndKill()
-            throws InterruptedException, TimeoutRuntimeException, CommandExecutionException;
+            throws InterruptedException, CommandExecutionException;
 
     void waitForWithTimeoutAndKill(Duration timeout)
-            throws InterruptedException, TimeoutRuntimeException, CommandExecutionException;
+            throws InterruptedException, CommandExecutionException;
 }

--- a/tempto-core/src/main/java/com/teradata/tempto/process/JavaProcessLauncher.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/process/JavaProcessLauncher.java
@@ -27,18 +27,18 @@ public final class JavaProcessLauncher
     private final String javaBin;
     private final String classpath;
 
+    public JavaProcessLauncher(String javaBin, String classpath)
+    {
+        this.javaBin = javaBin;
+        this.classpath = classpath;
+    }
+
     public static JavaProcessLauncher defaultJavaProcessLauncher()
     {
         return new JavaProcessLauncher(
                 System.getProperty("java.home") + File.separator + "bin" + File.separator + "java",
                 System.getProperty("java.class.path")
         );
-    }
-
-    public JavaProcessLauncher(String javaBin, String classpath)
-    {
-        this.javaBin = javaBin;
-        this.classpath = classpath;
     }
 
     public Process launch(Class clazz, List<String> arguments)

--- a/tempto-core/src/main/java/com/teradata/tempto/sql/SqlContexts.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/sql/SqlContexts.java
@@ -22,6 +22,10 @@ import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 public final class SqlContexts
 {
 
+    private SqlContexts()
+    {
+    }
+
     /**
      * Helper method designed to be used with lambda expressions containing assertions used
      * on newly created view:
@@ -44,9 +48,5 @@ public final class SqlContexts
     private static String generateRandomName(String prefix)
     {
         return prefix + randomAlphanumeric(4);
-    }
-
-    private SqlContexts()
-    {
     }
 }

--- a/tempto-core/src/test/groovy/com/teradata/tempto/util/DateTimeUtilsTest.java
+++ b/tempto-core/src/test/groovy/com/teradata/tempto/util/DateTimeUtilsTest.java
@@ -30,9 +30,9 @@ public class DateTimeUtilsTest
     public void shouldParseMultipleFormatsInUTC()
             throws Exception
     {
-        assertThat(parseTimestampInUTC("2015-05-10 12:15:35.123").getTime()).isEqualTo(1431260135123l);
-        assertThat(parseTimestampInUTC("2015-05-10 12:15:35").getTime()).isEqualTo(1431260135000l);
-        assertThat(parseTimestampInUTC("2015-05-10 12:15").getTime()).isEqualTo(1431260100000l);
-        assertThat(parseTimestampInUTC("2015-05-10").getTime()).isEqualTo(1431216000000l);
+        assertThat(parseTimestampInUTC("2015-05-10 12:15:35.123").getTime()).isEqualTo(1431260135123L);
+        assertThat(parseTimestampInUTC("2015-05-10 12:15:35").getTime()).isEqualTo(1431260135000L);
+        assertThat(parseTimestampInUTC("2015-05-10 12:15").getTime()).isEqualTo(1431260100000L);
+        assertThat(parseTimestampInUTC("2015-05-10").getTime()).isEqualTo(1431216000000L);
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
squid:S2275 - Printf-style format strings should not lead to unexpected behavior at runtime.
squid:MissingDeprecatedCheck - Deprecated elements should have both the annotation and the Javadoc tag.
squid:RedundantThrowsDeclarationCheck - Throws declarations should not be superfluous.
squid:S2259 - Null pointers should not be dereferenced.
squid:LowerCaseLongSuffixCheck - Long suffix "L" should be upper case.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1149
https://dev.eclipse.org/sonar/rules/show/squid:S2275
https://dev.eclipse.org/sonar/rules/show/squid:MissingDeprecatedCheck
https://dev.eclipse.org/sonar/rules/show/squid:RedundantThrowsDeclarationCheck
https://dev.eclipse.org/sonar/rules/show/squid:S2259
https://dev.eclipse.org/sonar/rules/show/squid:LowerCaseLongSuffixCheck
Please let me know if you have any questions.
George Kankava