### PR TITLE
Create a stub of SPI for testing modules

### DIFF
--- a/tempto-core/src/main/java/com/teradata/tempto/fulfillment/table/hive/HiveTableDefinition.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/fulfillment/table/hive/HiveTableDefinition.java
@@ -27,7 +27,6 @@ import static com.google.common.collect.Lists.newArrayList;
 import static com.teradata.tempto.fulfillment.table.TableHandle.tableHandle;
 import static com.teradata.tempto.fulfillment.table.hive.InlineDataSource.createSameRowDataSource;
 import static com.teradata.tempto.fulfillment.table.hive.InlineDataSource.createStringDataSource;
-import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals;
 import static org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode;
 

--- a/tempto-core/src/main/java/com/teradata/tempto/hive/HivePlugin.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/hive/HivePlugin.java
@@ -1,0 +1,43 @@
+package com.teradata.tempto.hive;
+
+import com.teradata.tempto.fulfillment.table.TableDefinition;
+import com.teradata.tempto.fulfillment.table.TableHandle;
+import com.teradata.tempto.fulfillment.table.hive.HiveDataSource;
+import com.teradata.tempto.internal.convention.tabledefinitions.FileBasedHiveDataSource;
+import com.teradata.tempto.spi.Plugin;
+import com.teradata.tempto.spi.convention.tabledefinitions.ConventionTableDefinitionDescriptor;
+
+import java.util.Optional;
+
+import static com.teradata.tempto.fulfillment.table.TableHandle.tableHandle;
+import static com.teradata.tempto.fulfillment.table.hive.HiveTableDefinition.hiveTableDefinition;
+
+public class HivePlugin
+    implements Plugin
+{
+    @Override
+    public TableDefinition getConventionTableDefinition(ConventionTableDefinitionDescriptor descriptor)
+    {
+        HiveDataSource dataSource = new FileBasedHiveDataSource(descriptor);
+        return hiveTableDefinition(
+                getTableHandle(descriptor),
+                descriptor.getParsedDDLFile().getContent(),
+                dataSource);
+    }
+
+    @Override
+    public String getName()
+    {
+        return "hive";
+    }
+
+    private TableHandle getTableHandle(ConventionTableDefinitionDescriptor tableDefinitionDescriptor)
+    {
+        TableHandle tableHandle = tableHandle(tableDefinitionDescriptor.getName());
+        Optional<String> schema = tableDefinitionDescriptor.getParsedDDLFile().getSchema();
+        if (schema.isPresent()) {
+            tableHandle = tableHandle.inSchema(schema.get());
+        }
+        return tableHandle;
+    }
+}

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/ReflectionHelper.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/ReflectionHelper.java
@@ -79,10 +79,14 @@ public final class ReflectionHelper
     @SuppressWarnings("unchecked")
     public static <T> Set<Class<? extends T>> getAnnotatedSubTypesOf(Class<T> clazz, Class<? extends Annotation> annotation)
     {
-        Set<Class<? extends T>> subtypesOf = (Set) SUBTYPES_OF.getUnchecked(clazz);
-        return subtypesOf.stream()
+        return getSubTypesOf(clazz).stream()
                 .filter(c -> c.getAnnotation(annotation) != null)
                 .collect(toSet());
+    }
+
+    public static <T> Set<Class<? extends T>> getSubTypesOf(Class<T> clazz)
+    {
+        return (Set) SUBTYPES_OF.getUnchecked(clazz);
     }
 
     public static <T> List<? extends T> instantiate(Collection<Class<? extends T>> classes)

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/convention/tabledefinitions/FileBasedHiveDataSource.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/convention/tabledefinitions/FileBasedHiveDataSource.java
@@ -17,6 +17,7 @@ package com.teradata.tempto.internal.convention.tabledefinitions;
 import com.google.common.collect.ImmutableSet;
 import com.teradata.tempto.fulfillment.table.hive.HiveDataSource;
 import com.teradata.tempto.hadoop.hdfs.HdfsClient.RepeatableContentProducer;
+import com.teradata.tempto.spi.convention.tabledefinitions.ConventionTableDefinitionDescriptor;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/convention/tabledefinitions/FileBasedJdbcDataSource.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/convention/tabledefinitions/FileBasedJdbcDataSource.java
@@ -15,6 +15,7 @@
 package com.teradata.tempto.internal.convention.tabledefinitions;
 
 import com.teradata.tempto.fulfillment.table.jdbc.JdbcTableDataSource;
+import com.teradata.tempto.spi.convention.tabledefinitions.ConventionTableDefinitionDescriptor;
 
 import java.util.Iterator;
 import java.util.List;

--- a/tempto-core/src/main/java/com/teradata/tempto/jdbc/JdbcPlugin.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/jdbc/JdbcPlugin.java
@@ -1,0 +1,43 @@
+package com.teradata.tempto.jdbc;
+
+import com.teradata.tempto.fulfillment.table.TableDefinition;
+import com.teradata.tempto.fulfillment.table.TableHandle;
+import com.teradata.tempto.fulfillment.table.jdbc.JdbcTableDataSource;
+import com.teradata.tempto.internal.convention.tabledefinitions.FileBasedJdbcDataSource;
+import com.teradata.tempto.spi.Plugin;
+import com.teradata.tempto.spi.convention.tabledefinitions.ConventionTableDefinitionDescriptor;
+
+import java.util.Optional;
+
+import static com.teradata.tempto.fulfillment.table.TableHandle.tableHandle;
+import static com.teradata.tempto.fulfillment.table.jdbc.JdbcTableDefinition.jdbcTableDefinition;
+
+public class JdbcPlugin
+        implements Plugin
+{
+    @Override
+    public TableDefinition getConventionTableDefinition(ConventionTableDefinitionDescriptor descriptor)
+    {
+        JdbcTableDataSource dataSource = new FileBasedJdbcDataSource(descriptor);
+        return jdbcTableDefinition(
+                getTableHandle(descriptor),
+                descriptor.getParsedDDLFile().getContent(),
+                dataSource);
+    }
+
+    @Override
+    public String getName()
+    {
+        return "jdbc";
+    }
+
+    private TableHandle getTableHandle(ConventionTableDefinitionDescriptor tableDefinitionDescriptor)
+    {
+        TableHandle tableHandle = tableHandle(tableDefinitionDescriptor.getName());
+        Optional<String> schema = tableDefinitionDescriptor.getParsedDDLFile().getSchema();
+        if (schema.isPresent()) {
+            tableHandle = tableHandle.inSchema(schema.get());
+        }
+        return tableHandle;
+    }
+}

--- a/tempto-core/src/main/java/com/teradata/tempto/spi/Plugin.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/spi/Plugin.java
@@ -1,0 +1,14 @@
+package com.teradata.tempto.spi;
+
+import com.teradata.tempto.fulfillment.table.TableDefinition;
+import com.teradata.tempto.spi.convention.tabledefinitions.ConventionTableDefinitionDescriptor;
+
+public interface Plugin
+{
+    TableDefinition getConventionTableDefinition(ConventionTableDefinitionDescriptor descriptor);
+
+    /**
+     * Name of plugin, in all lower case
+     */
+    String getName();
+}

--- a/tempto-core/src/main/java/com/teradata/tempto/spi/convention/tabledefinitions/ConventionTableDefinitionDescriptor.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/spi/convention/tabledefinitions/ConventionTableDefinitionDescriptor.java
@@ -12,11 +12,12 @@
  * limitations under the License.
  */
 
-package com.teradata.tempto.internal.convention.tabledefinitions;
+package com.teradata.tempto.spi.convention.tabledefinitions;
 
 import com.teradata.tempto.internal.convention.AnnotatedFileParser;
 import com.teradata.tempto.internal.convention.AnnotatedFileParser.SectionParsingResult;
 import com.teradata.tempto.internal.convention.SqlDescriptor;
+import com.teradata.tempto.internal.convention.tabledefinitions.TableType;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -30,7 +31,7 @@ import static com.teradata.tempto.internal.convention.SqlTestsFileUtils.getFilen
 import static java.nio.file.Files.exists;
 import static java.nio.file.Files.isRegularFile;
 
-class ConventionTableDefinitionDescriptor
+public class ConventionTableDefinitionDescriptor
 {
     public static class ParsedDDLFile
             extends SqlDescriptor


### PR DESCRIPTION
This enables us to remove hack in `ConventionTableDefinitionsProvider` with a switch containing all existsing "plugins".
This patch is a prerequisite to extract Hive and Jdbc plugins to separate modules.
