### PR TITLE
Add dedicated TableDefinition for Cassandra

### DIFF
--- a/tempto-core/src/main/java/com/teradata/tempto/fulfillment/table/jdbc/RelationalTableDefinition.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/fulfillment/table/jdbc/RelationalTableDefinition.java
@@ -41,7 +41,7 @@ public class RelationalTableDefinition
 
     private final String createTableDDLTemplate;
 
-    private RelationalTableDefinition(TableHandle handle, String createTableDDLTemplate, RelationalDataSource dataSource)
+    protected RelationalTableDefinition(TableHandle handle, String createTableDDLTemplate, RelationalDataSource dataSource)
     {
         super(handle);
         ;
@@ -94,7 +94,7 @@ public class RelationalTableDefinition
         private String createTableDDLTemplate;
         private RelationalDataSource dataSource;
 
-        private RelationalTableDefinitionBuilder(String name)
+        protected RelationalTableDefinitionBuilder(String name)
         {
             this.handle = tableHandle(name);
         }

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/fulfillment/table/cassandra/CassandraTableDefinition.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/fulfillment/table/cassandra/CassandraTableDefinition.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.teradata.tempto.internal.fulfillment.table.cassandra;
+
+import com.teradata.tempto.fulfillment.table.TableHandle;
+import com.teradata.tempto.fulfillment.table.jdbc.RelationalDataSource;
+import com.teradata.tempto.fulfillment.table.jdbc.RelationalTableDefinition;
+
+import static com.teradata.tempto.fulfillment.table.TableHandle.tableHandle;
+
+public class CassandraTableDefinition
+    extends RelationalTableDefinition
+{
+    public CassandraTableDefinition(String name, String createTableDDLTemplate, RelationalDataSource dataSource)
+    {
+        super(tableHandle(name), createTableDDLTemplate, dataSource);
+    }
+
+    public CassandraTableDefinition(TableHandle handle, String createTableDDLTemplate, RelationalDataSource dataSource)
+    {
+        super(handle, createTableDDLTemplate, dataSource);
+    }
+
+    public static CassandraTableDefinitionBuilder builder(String name)
+    {
+        return new CassandraTableDefinitionBuilder(name);
+    }
+
+    public static class CassandraTableDefinitionBuilder
+            extends RelationalTableDefinitionBuilder
+    {
+        private CassandraTableDefinitionBuilder(String name)
+        {
+            super(name);
+        }
+
+        @Override
+        public CassandraTableDefinitionBuilder withSchema(String schema)
+        {
+            return (CassandraTableDefinitionBuilder) super.withSchema(schema);
+        }
+
+        @Override
+        public CassandraTableDefinitionBuilder withDatabase(String database)
+        {
+            return (CassandraTableDefinitionBuilder) super.withDatabase(database);
+        }
+
+        @Override
+        public CassandraTableDefinitionBuilder setCreateTableDDLTemplate(String createTableDDLTemplate)
+        {
+            return (CassandraTableDefinitionBuilder) super.setCreateTableDDLTemplate(createTableDDLTemplate);
+        }
+
+        @Override
+        public CassandraTableDefinitionBuilder setDataSource(RelationalDataSource dataSource)
+        {
+            return (CassandraTableDefinitionBuilder) super.setDataSource(dataSource);
+        }
+
+
+        @Override
+        public CassandraTableDefinition build()
+        {
+            return (CassandraTableDefinition) super.build();
+        }
+    }
+}

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/fulfillment/table/cassandra/CassandraTableInstance.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/fulfillment/table/cassandra/CassandraTableInstance.java
@@ -18,9 +18,9 @@ import com.teradata.tempto.fulfillment.table.jdbc.RelationalTableDefinition;
 import com.teradata.tempto.internal.fulfillment.table.TableName;
 
 public class CassandraTableInstance
-        extends TableInstance<RelationalTableDefinition>
+        extends TableInstance<CassandraTableDefinition>
 {
-    protected CassandraTableInstance(TableName name, RelationalTableDefinition tableDefinition)
+    protected CassandraTableInstance(TableName name, CassandraTableDefinition tableDefinition)
     {
         super(name, tableDefinition);
     }

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/fulfillment/table/cassandra/CassandraTableManager.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/fulfillment/table/cassandra/CassandraTableManager.java
@@ -21,7 +21,6 @@ import com.teradata.tempto.fulfillment.table.TableHandle;
 import com.teradata.tempto.fulfillment.table.TableInstance;
 import com.teradata.tempto.fulfillment.table.TableManager;
 import com.teradata.tempto.fulfillment.table.jdbc.RelationalDataSource;
-import com.teradata.tempto.fulfillment.table.jdbc.RelationalTableDefinition;
 import com.teradata.tempto.internal.fulfillment.table.TableName;
 import com.teradata.tempto.internal.fulfillment.table.TableNameGenerator;
 import com.teradata.tempto.internal.query.CassandraQueryExecutor;
@@ -45,10 +44,10 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static org.slf4j.LoggerFactory.getLogger;
 
-@TableManager.Descriptor(tableDefinitionClass = RelationalTableDefinition.class, type = "CASSANDRA")
+@TableManager.Descriptor(tableDefinitionClass = CassandraTableDefinition.class, type = "CASSANDRA")
 @Singleton
 public class CassandraTableManager
-        implements TableManager<RelationalTableDefinition>
+        implements TableManager<CassandraTableDefinition>
 {
     private static final Logger LOGGER = getLogger(CassandraTableManager.class);
 
@@ -74,7 +73,7 @@ public class CassandraTableManager
     }
 
     @Override
-    public TableInstance<RelationalTableDefinition> createImmutable(RelationalTableDefinition tableDefinition, TableHandle tableHandle)
+    public TableInstance<CassandraTableDefinition> createImmutable(CassandraTableDefinition tableDefinition, TableHandle tableHandle)
     {
         TableName tableName = createImmutableTableName(tableHandle);
 
@@ -142,7 +141,7 @@ public class CassandraTableManager
     }
 
     @Override
-    public TableInstance<RelationalTableDefinition> createMutable(RelationalTableDefinition tableDefinition, MutableTableRequirement.State state, TableHandle tableHandle)
+    public TableInstance<CassandraTableDefinition> createMutable(CassandraTableDefinition tableDefinition, MutableTableRequirement.State state, TableHandle tableHandle)
     {
         TableName tableName = createMutableTableName(tableHandle);
         if (!tableName.getSchema().get().equals(defaultKeySpace)) {
@@ -191,7 +190,7 @@ public class CassandraTableManager
     @Override
     public Class<? extends TableDefinition> getTableDefinitionClass()
     {
-        return RelationalTableDefinition.class;
+        return CassandraTableDefinition.class;
     }
 
     @Override


### PR DESCRIPTION
This enables using Cassandra product tests in the same suite
along with other relational requirements (e.g. MySQL, PSQL etc.).