### PR TITLE
Remove LIMIT for Batch Loader

### DIFF
--- a/tempto-core/src/main/java/com/teradata/tempto/internal/fulfillment/table/jdbc/JdbcTableManager.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/fulfillment/table/jdbc/JdbcTableManager.java
@@ -188,7 +188,7 @@ public class JdbcTableManager
         if (!dataRows.hasNext()) {
             return;
         }
-        try (Loader loader = new LoaderFactory().create(queryExecutor, tableName.getSchema(), tableName.getSchemalessNameInDatabase())) {
+        try (Loader loader = new LoaderFactory().create(queryExecutor, tableName.getNameInDatabase())) {
             for (List<List<Object>> batch : partitionBy(dataRows, BATCH_SIZE)) {
                 loader.load(batch);
             }

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/fulfillment/table/jdbc/JdbcTableManager.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/fulfillment/table/jdbc/JdbcTableManager.java
@@ -188,7 +188,7 @@ public class JdbcTableManager
         if (!dataRows.hasNext()) {
             return;
         }
-        try (Loader loader = new LoaderFactory().create(queryExecutor, tableName.getNameInDatabase())) {
+        try (Loader loader = new LoaderFactory().create(queryExecutor, tableName.getSchema(), tableName.getSchemalessNameInDatabase())) {
             for (List<List<Object>> batch : partitionBy(dataRows, BATCH_SIZE)) {
                 loader.load(batch);
             }

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/fulfillment/table/jdbc/LoaderFactory.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/fulfillment/table/jdbc/LoaderFactory.java
@@ -18,11 +18,8 @@ import com.teradata.tempto.query.QueryExecutor;
 import org.slf4j.Logger;
 
 import java.sql.JDBCType;
-import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -30,16 +27,10 @@ class LoaderFactory
 {
     private static final Logger LOGGER = getLogger(LoaderFactory.class);
 
-    Loader create(QueryExecutor queryExecutor, Optional<String> schema, String tableName)
+    Loader create(QueryExecutor queryExecutor, String tableName)
             throws SQLException
     {
-        schema = getSchema(queryExecutor);
-        ResultSet resultSet = queryExecutor.getConnection().getMetaData().getColumns(null, schema.orElse(""), tableName, null);
-
-        List<JDBCType> columnTypes = new ArrayList<>();
-        while (resultSet.next()) {
-            columnTypes.add(JDBCType.valueOf(resultSet.getInt("DATA_TYPE")));
-        }
+        List<JDBCType> columnTypes = queryExecutor.executeQuery("SELECT * FROM " + tableName + " WHERE 1=2").getColumnTypes();
 
         try {
             return new BatchLoader(queryExecutor, tableName, columnTypes.size());
@@ -49,14 +40,4 @@ class LoaderFactory
             return new InsertLoader(queryExecutor, tableName, columnTypes);
         }
     }
-
-    private Optional<String> getSchema (QueryExecutor queryExecutor){
-        try {
-            return Optional.ofNullable(queryExecutor.getConnection().getSchema());
-        }
-        catch (Exception e) {
-            return Optional.empty();
-        }
-}
-
 }


### PR DESCRIPTION
LIMIT doesn't exist for SQL Server, hence we need a different method to
get the column count for creating Batch Loader