### PR TITLE
Add content-type header to WebHdfs requests

### DIFF
--- a/tempto-core/src/main/java/com/teradata/tempto/internal/hadoop/hdfs/WebHdfsClient.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/hadoop/hdfs/WebHdfsClient.java
@@ -151,6 +151,7 @@ public class WebHdfsClient
         String writeRedirectUri = executeAndGetRedirectUri(new HttpPut(
                 buildUri(path, "CREATE", ImmutableMap.of("overwrite", "true"))));
         HttpPut writeRequest = new HttpPut(writeRedirectUri);
+        writeRequest.addHeader("content-type", "application/octet-stream");
         writeRequest.setEntity(entity);
 
         try (CloseableHttpResponse response = httpRequestsExecutor.execute(writeRequest)) {


### PR DESCRIPTION
- This change is needed because MapR uses HttpFS to
  interact with WebHDFS and that requires the content-type
  header to be included.