### PR TITLE
Use Lazy<CassandraQueryExecutor> in CassandraTableManager

### DIFF
--- a/tempto-core/src/main/java/com/teradata/tempto/internal/hadoop/hdfs/revisions/DispatchingRevisionStorage.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/hadoop/hdfs/revisions/DispatchingRevisionStorage.java
@@ -15,7 +15,7 @@
 package com.teradata.tempto.internal.hadoop.hdfs.revisions;
 
 import com.teradata.tempto.hadoop.hdfs.HdfsClient;
-import com.teradata.tempto.util.LazyCachingProvider;
+import com.teradata.tempto.util.Lazy;
 import org.slf4j.Logger;
 
 import javax.inject.Inject;
@@ -41,7 +41,7 @@ public class DispatchingRevisionStorage
     @Inject
     public DispatchingRevisionStorage(HdfsClient hdfsClient, @Named(CONF_TESTS_HDFS_PATH_KEY) String testDataBasePath)
     {
-        revisionStorage = new LazyCachingProvider(new HdfsRevisionStorageProvider(hdfsClient, testDataBasePath));
+        revisionStorage = new Lazy(new HdfsRevisionStorageProvider(hdfsClient, testDataBasePath));
     }
 
     @Override

--- a/tempto-core/src/main/java/com/teradata/tempto/util/Lazy.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/util/Lazy.java
@@ -14,10 +14,14 @@
 
 package com.teradata.tempto.util;
 
+import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Provider;
+
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
+@ThreadSafe
 public class Lazy<T>
         implements Provider<T>
 {
@@ -36,5 +40,10 @@ public class Lazy<T>
             instance = provider.get();
         }
         return instance;
+    }
+
+    public synchronized Optional<T> lazyGet()
+    {
+        return Optional.ofNullable(instance);
     }
 }

--- a/tempto-core/src/main/java/com/teradata/tempto/util/Lazy.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/util/Lazy.java
@@ -18,13 +18,13 @@ import javax.inject.Provider;
 
 import static java.util.Objects.requireNonNull;
 
-public class LazyCachingProvider<T>
+public class Lazy<T>
         implements Provider<T>
 {
     private final Provider<T> provider;
     private T instance;
 
-    public LazyCachingProvider(Provider<T> provider)
+    public Lazy(Provider<T> provider)
     {
         this.provider = requireNonNull(provider, "provider is null");
     }

--- a/tempto-core/src/main/java/com/teradata/tempto/util/Lazy.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/util/Lazy.java
@@ -37,7 +37,7 @@ public class Lazy<T>
     public synchronized T get()
     {
         if (instance == null) {
-            instance = provider.get();
+            instance = requireNonNull(provider.get());
         }
         return instance;
     }


### PR DESCRIPTION
Use Lazy<CassandraQueryExecutor> in CassandraTableManager

Thanks to that when CassandraTableManager is not effectively used, then
it does not require to instantiate the CassandraQueryExecutor.
