### PR TITLE
Expose database configuration to table managers

### DIFF
--- a/tempto-core/src/main/java/com/teradata/tempto/internal/fulfillment/table/TableManagerDispatcherModuleProvider.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/fulfillment/table/TableManagerDispatcherModuleProvider.java
@@ -91,6 +91,9 @@ public class TableManagerDispatcherModuleProvider
                             // we bind matching QueryExecutor to be visible by TableManager without @Named annotation
                             bind(QueryExecutor.class).to(Key.get(QueryExecutor.class, named(database)));
                         }
+                        databaseConfiguration.listKeys().forEach(key ->
+                                databaseConfiguration.getString(key).ifPresent(value ->
+                                        bind(Key.get(String.class, named(key))).toInstance(value)));
                         bind(Key.get(String.class, named("databaseName"))).toInstance(database);
                         bind(tableManagerKey).to(tableManagerClass);
                         expose(tableManagerKey);

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/fulfillment/table/hive/HiveTableManager.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/fulfillment/table/hive/HiveTableManager.java
@@ -63,9 +63,9 @@ public class HiveTableManager
             TableNameGenerator tableNameGenerator,
             @Named("tests.hdfs.path") String testDataBasePath,
             @Named("databaseName") String databaseName,
-            @Named("databases.hive.path") String databasePath,
-            @Named("databases.hive.analyze_immutable_tables") boolean analyzeImmutableTables,
-            @Named("databases.hive.analyze_mutable_tables") boolean analyzeMutableTables)
+            @Named("path") String databasePath,
+            @Named("analyze_immutable_tables") boolean analyzeImmutableTables,
+            @Named("analyze_mutable_tables") boolean analyzeMutableTables)
     {
         super(queryExecutor, tableNameGenerator);
         this.databaseName = databaseName;


### PR DESCRIPTION
Expose database configuration to table managers

Currently hive configuration was injected with absolute keys, this was
bad as it was limiting to support only single hive table manager and
required that it was named hive.

This patch removes such limitation.
