### PR TITLE
Do not inject statistics for partitioned hive tables

### DIFF
--- a/tempto-core/src/main/java/com/teradata/tempto/assertions/QueryAssert.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/assertions/QueryAssert.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.teradata.tempto.configuration.Configuration;
 import com.teradata.tempto.internal.convention.SqlResultDescriptor;
 import com.teradata.tempto.internal.query.QueryResultValueComparator;
+import com.teradata.tempto.internal.query.QueryRowMapper;
 import com.teradata.tempto.query.QueryExecutionException;
 import com.teradata.tempto.query.QueryExecutor;
 import com.teradata.tempto.query.QueryResult;
@@ -485,7 +486,10 @@ public class QueryAssert
         @Override
         public String toString()
         {
-            return "anyOf(" + Joiner.on(", ").join(values) + ")";
+            String jointValues = Joiner.on(", ")
+                    .useForNull(QueryRowMapper.NULL_STRING)
+                    .join(values);
+            return "anyOf(" + jointValues + ")";
         }
     }
 }

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/fulfillment/table/hive/HiveTableManager.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/fulfillment/table/hive/HiveTableManager.java
@@ -209,8 +209,7 @@ public class HiveTableManager
     }
 
     private void injectStatistics(HiveTableDefinition tableDefinition, TableName tableName) {
-        if (tableDefinition.getDataSource().getStatistics().isPresent()) {
-            checkState(!tableDefinition.isPartitioned(), "Statisitcs are not supported for parititioned tables");
+        if (!tableDefinition.isPartitioned() && tableDefinition.getDataSource().getStatistics().isPresent()) {
             hiveThriftClient.setStatistics(tableName, tableDefinition.getDataSource().getStatistics().get());
         }
     }

--- a/tempto-core/src/main/java/com/teradata/tempto/internal/query/QueryRowMapper.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/internal/query/QueryRowMapper.java
@@ -35,7 +35,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class QueryRowMapper
 {
-    private static final String NULL_STRING = "null";
+    public static final String NULL_STRING = "null";
 
     private final List<JDBCType> columnTypes;
 

--- a/tempto-core/src/test/groovy/com/teradata/tempto/assertions/QueryAssertTest.groovy
+++ b/tempto-core/src/test/groovy/com/teradata/tempto/assertions/QueryAssertTest.groovy
@@ -288,13 +288,13 @@ public class QueryAssertTest
     assertThat(NATION_JOIN_REGION_QUERY_RESULT)
             .contains(
             row(2, "ARGENTINA", "SOUTH AMERICA"),
-            row(1, "ALGERIA", anyOf("SATURN", "MARS")),
+            row(1, "ALGERIA", anyOf("SATURN", null)),
     )
 
     then:
     def e = thrown(AssertionError)
     e.message == 'Could not find rows:\n' +
-            '[1, ALGERIA, anyOf(SATURN, MARS)]\n' +
+            '[1, ALGERIA, anyOf(SATURN, null)]\n' +
             '\n' +
             'actual rows:\n' +
             '[1, ALGERIA, AFRICA]\n' +


### PR DESCRIPTION
Do not inject statistics for partitioned hive tables

For partitioned hive table definition does not provide data source, and
so it is not possible to inject stats for such data source.
