### PR TITLE
Fix PreparedStatement.execute() invocation

### DIFF
--- a/tempto-core/src/main/java/com/teradata/tempto/query/JdbcQueryExecutor.java
+++ b/tempto-core/src/main/java/com/teradata/tempto/query/JdbcQueryExecutor.java
@@ -145,7 +145,7 @@ public class JdbcQueryExecutor
         try (PreparedStatement statement = getConnection().prepareStatement(sql)) {
             setQueryParams(statement, params);
 
-            if (statement.execute(sql)) {
+            if (statement.execute()) {
                 return QueryResult.forResultSet(statement.getResultSet());
             }
             else {


### PR DESCRIPTION
`execute()` should be called rather than `execute(String sql)` since
the `PreparedStatement` already knows the `sql`.