### PR TITLE
Allow fine control over injecting table statistics into Hive tables

### DIFF
--- a/tempto-core/src/main/java/io/prestodb/tempto/fulfillment/table/hive/HiveTableDefinition.java
+++ b/tempto-core/src/main/java/io/prestodb/tempto/fulfillment/table/hive/HiveTableDefinition.java
@@ -60,7 +60,7 @@ public class HiveTableDefinition
         return dataSource.get();
     }
 
-    public List<PartitionDefinition> getPartitionDefinitons()
+    public List<PartitionDefinition> getPartitionDefinitions()
     {
         checkState(isPartitioned(), "not supported for not partitioned table");
         return partitionDefinitions.get();

--- a/tempto-core/src/main/java/io/prestodb/tempto/fulfillment/table/hive/HiveTableDefinition.java
+++ b/tempto-core/src/main/java/io/prestodb/tempto/fulfillment/table/hive/HiveTableDefinition.java
@@ -111,6 +111,11 @@ public class HiveTableDefinition
         return new HiveTableDefinitionBuilder(name);
     }
 
+    public static HiveTableDefinitionBuilder from(HiveTableDefinition initialDefinition)
+    {
+        return new HiveTableDefinitionBuilder(initialDefinition);
+    }
+
     public static HiveTableDefinitionBuilder like(HiveTableDefinition hiveTableDefinition)
     {
         HiveTableDefinitionBuilder hiveTableDefinitionBuilder = new HiveTableDefinitionBuilder(hiveTableDefinition.getName());
@@ -129,6 +134,16 @@ public class HiveTableDefinition
         private Optional<HiveDataSource> dataSource = Optional.empty();
         private Optional<List<PartitionDefinition>> partitionDefinitions = Optional.empty();
         private Optional<Boolean> injectStats = Optional.empty();
+
+        private HiveTableDefinitionBuilder(HiveTableDefinition initialDefinition)
+        {
+            requireNonNull(initialDefinition, "initialDefinition is null");
+            this.handle = initialDefinition.handle;
+            this.createTableDDLTemplate = initialDefinition.createTableDDLTemplate;
+            this.dataSource = initialDefinition.dataSource;
+            this.partitionDefinitions = initialDefinition.partitionDefinitions;
+            this.injectStats = initialDefinition.injectStats;
+        }
 
         private HiveTableDefinitionBuilder(String name)
         {

--- a/tempto-core/src/main/java/io/prestodb/tempto/fulfillment/table/hive/HiveTableDefinition.java
+++ b/tempto-core/src/main/java/io/prestodb/tempto/fulfillment/table/hive/HiveTableDefinition.java
@@ -46,7 +46,7 @@ public class HiveTableDefinition
     private HiveTableDefinition(TableHandle handle, String createTableDDLTemplate, Optional<HiveDataSource> dataSource, Optional<List<PartitionDefinition>> partitionDefinitions)
     {
         super(handle);
-        checkArgument(dataSource.isPresent() ^ partitionDefinitions.isPresent(), "either dataSource or partitionDefinitions must be set");
+        checkArgument(dataSource.isPresent() ^ partitionDefinitions.isPresent(), "either dataSource or partitionDefinitions must be set (but not both)");
         this.dataSource = dataSource;
         this.partitionDefinitions = partitionDefinitions;
         this.createTableDDLTemplate = createTableDDLTemplate;

--- a/tempto-core/src/main/java/io/prestodb/tempto/fulfillment/table/hive/HiveTableDefinition.java
+++ b/tempto-core/src/main/java/io/prestodb/tempto/fulfillment/table/hive/HiveTableDefinition.java
@@ -46,7 +46,7 @@ public class HiveTableDefinition
     private HiveTableDefinition(TableHandle handle, String createTableDDLTemplate, Optional<HiveDataSource> dataSource, Optional<List<PartitionDefinition>> partitionDefinitions)
     {
         super(handle);
-        checkArgument(dataSource.isPresent() ^ partitionDefinitions.isPresent(), "either dataSource or partitionDefinitions must be set (but not both)");
+        checkArgument(dataSource.isPresent() != partitionDefinitions.isPresent(), "either dataSource or partitionDefinitions must be set (but not both)");
         this.dataSource = dataSource;
         this.partitionDefinitions = partitionDefinitions;
         this.createTableDDLTemplate = createTableDDLTemplate;

--- a/tempto-core/src/main/java/io/prestodb/tempto/internal/fulfillment/table/hive/HiveTableManager.java
+++ b/tempto-core/src/main/java/io/prestodb/tempto/internal/fulfillment/table/hive/HiveTableManager.java
@@ -53,8 +53,8 @@ public class HiveTableManager
     private final HiveThriftClient hiveThriftClient;
     private final String databaseName;
     private final String hiveDatabasePath;
-    private final boolean analyzeImmutableTables;
-    private final boolean analyzeMutableTables;
+    private final boolean injectStatsForImmutableTables;
+    private final boolean injectStatsForMutableTables;
 
     @Inject
     public HiveTableManager(
@@ -64,8 +64,8 @@ public class HiveTableManager
             @Named("tests.hdfs.path") String testDataBasePath,
             @Named("databaseName") String databaseName,
             @Named("path") String databasePath,
-            @Named("inject_stats_for_immutable_tables") boolean analyzeImmutableTables,
-            @Named("inject_stats_for_mutable_tables") boolean analyzeMutableTables,
+            @Named("inject_stats_for_immutable_tables") boolean injectStatsForImmutableTables,
+            @Named("inject_stats_for_mutable_tables") boolean injectStatsForMutableTables,
             @Named("metastore.host") String thriftHost,
             @Named("metastore.port") String thriftPort)
     {
@@ -77,8 +77,8 @@ public class HiveTableManager
                 testDataBasePath,
                 databaseName,
                 databasePath,
-                analyzeImmutableTables,
-                analyzeMutableTables);
+                injectStatsForImmutableTables,
+                injectStatsForMutableTables);
     }
 
     public HiveTableManager(
@@ -89,8 +89,8 @@ public class HiveTableManager
             String testDataBasePath,
             String databaseName,
             String databasePath,
-            boolean analyzeImmutableTables,
-            boolean analyzeMutableTables)
+            boolean injectStatsForImmutableTables,
+            boolean injectStatsForMutableTables)
     {
         super(queryExecutor, tableNameGenerator);
         this.hiveThriftClient = hiveThriftClient;
@@ -103,8 +103,8 @@ public class HiveTableManager
             databasePath += "/";
         }
         this.hiveDatabasePath = databasePath;
-        this.analyzeImmutableTables = analyzeImmutableTables;
-        this.analyzeMutableTables = analyzeMutableTables;
+        this.injectStatsForImmutableTables = injectStatsForImmutableTables;
+        this.injectStatsForMutableTables = injectStatsForMutableTables;
     }
 
     @Override
@@ -120,7 +120,7 @@ public class HiveTableManager
         dropTableIgnoreError(tableName);
         createTable(tableDefinition, tableName, Optional.of(tableDataPath));
         markTableAsExternal(tableName);
-        if (analyzeImmutableTables) {
+        if (injectStatsForImmutableTables) {
             injectStatistics(tableDefinition, tableName);
         }
 
@@ -155,7 +155,7 @@ public class HiveTableManager
             uploadTableData(tableDataPath, tableDefinition.getDataSource());
         }
 
-        if (state == LOADED && analyzeMutableTables) {
+        if (state == LOADED && injectStatsForMutableTables) {
             injectStatistics(tableDefinition, tableName);
         }
 

--- a/tempto-core/src/main/java/io/prestodb/tempto/internal/fulfillment/table/hive/HiveTableManager.java
+++ b/tempto-core/src/main/java/io/prestodb/tempto/internal/fulfillment/table/hive/HiveTableManager.java
@@ -141,7 +141,7 @@ public class HiveTableManager
 
         if (tableDefinition.isPartitioned()) {
             int partitionId = 0;
-            for (HiveTableDefinition.PartitionDefinition partitionDefinition : tableDefinition.getPartitionDefinitons()) {
+            for (HiveTableDefinition.PartitionDefinition partitionDefinition : tableDefinition.getPartitionDefinitions()) {
                 String partitionDataPath = getMutableTableHdfsPath(tableName, Optional.of(partitionId));
                 if (state == LOADED) {
                     uploadTableData(partitionDataPath, partitionDefinition.getDataSource());

--- a/tempto-core/src/main/java/io/prestodb/tempto/internal/query/QueryResultValueComparator.java
+++ b/tempto-core/src/main/java/io/prestodb/tempto/internal/query/QueryResultValueComparator.java
@@ -64,7 +64,7 @@ public class QueryResultValueComparator
         if (isNull(actual) && isNull(expected)) {
             return 0;
         }
-        if (isNull(actual) ^ isNull(expected)) {
+        if (isNull(actual) != isNull(expected)) {
             return -1;
         }
         switch (type) {


### PR DESCRIPTION
Having global switches `inject_stats_for_mutable_tables` and
`inject_stats_for_immutable_tables` is good, but not flexible enough.