### PR TITLE
Remove protected Loggers

### DIFF
--- a/tempto-core/src/main/java/io/prestodb/tempto/ProductTest.java
+++ b/tempto-core/src/main/java/io/prestodb/tempto/ProductTest.java
@@ -24,5 +24,4 @@ import org.testng.annotations.Listeners;
 @Listeners({RequirementsExpanderInterceptor.class, TestInitializationListener.class, ProgressLoggingListener.class})
 public class ProductTest
 {
-    protected static final Logger LOGGER = LoggerFactory.getLogger(ProductTest.class);
 }

--- a/tempto-core/src/main/java/io/prestodb/tempto/fulfillment/table/TableDefinitionsRepository.java
+++ b/tempto-core/src/main/java/io/prestodb/tempto/fulfillment/table/TableDefinitionsRepository.java
@@ -39,7 +39,7 @@ import static java.util.stream.Collectors.toList;
  */
 public class TableDefinitionsRepository
 {
-    protected static final Logger LOGGER = LoggerFactory.getLogger(TableDefinitionsRepository.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TableDefinitionsRepository.class);
 
     /**
      * An annotation for {@link TableDefinition} static fields


### PR DESCRIPTION
`protected` `Logger`s make it harder to trace the source of log
messages, countering the purpose of logging.