### PR TITLE
Convert from Lists#transform to Stream#map

### DIFF
--- a/tempto-core/src/main/java/io/prestodb/tempto/Requirements.java
+++ b/tempto-core/src/main/java/io/prestodb/tempto/Requirements.java
@@ -20,8 +20,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.copyOf;
-import static com.google.common.collect.Lists.transform;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Sets.newHashSet;
 import static java.util.Arrays.asList;
 
@@ -47,19 +48,21 @@ public final class Requirements
 
     public static CompositeRequirement allOf(List<Requirement> requirements)
     {
-        return new MultiCompositeRequirement(copyOf(transform(wrapAsCompositeRequirements(requirements), ImmutableSet::<CompositeRequirement>of)));
+        return new MultiCompositeRequirement(wrapAsCompositeRequirements(requirements).stream()
+                .map(ImmutableSet::of)
+                .collect(toImmutableSet()));
     }
 
     private static List<CompositeRequirement> wrapAsCompositeRequirements(List<Requirement> requirements)
     {
-        return transform(requirements, (Requirement requirement) -> {
-            if (requirement instanceof CompositeRequirement) {
-                return (CompositeRequirement) requirement;
-            }
-            else {
-                return new SingletonCompositeRequirement(requirement);
-            }
-        });
+        return requirements.stream()
+                .map((Requirement requirement) -> {
+                    if (requirement instanceof CompositeRequirement) {
+                        return (CompositeRequirement) requirement;
+                    } else {
+                        return new SingletonCompositeRequirement(requirement);
+                    }
+                }).collect(toImmutableList());
     }
 
     private static class SingletonCompositeRequirement

--- a/tempto-core/src/main/java/io/prestodb/tempto/internal/DefaultRequirementsCollector.java
+++ b/tempto-core/src/main/java/io/prestodb/tempto/internal/DefaultRequirementsCollector.java
@@ -15,7 +15,6 @@
 package io.prestodb.tempto.internal;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import io.prestodb.tempto.CompositeRequirement;
 import io.prestodb.tempto.Requirement;
 import io.prestodb.tempto.Requirements;
@@ -29,11 +28,12 @@ import io.prestodb.tempto.fulfillment.command.TestCommandRequirement;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.prestodb.tempto.Requirements.compose;
-import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -92,7 +92,7 @@ public class DefaultRequirementsCollector
         {
             return configuration.getStringList(key).stream()
                     .map(Command::new)
-                    .collect(toList());
+                    .collect(toImmutableList());
         }
     }
 
@@ -131,7 +131,7 @@ public class DefaultRequirementsCollector
 
         private List<Requirement> toRequirements(Class<? extends RequirementsProvider>[] providers)
         {
-            return Lists.transform(asList(providers), (Class<? extends RequirementsProvider> providerClass) -> {
+            return Arrays.stream(providers).map((Class<? extends RequirementsProvider> providerClass) -> {
                 try {
                     Constructor<? extends RequirementsProvider> constructor = providerClass.getDeclaredConstructor();
                     constructor.setAccessible(true);
@@ -144,7 +144,7 @@ public class DefaultRequirementsCollector
                 catch (NoSuchMethodException e) {
                     throw new IllegalArgumentException("No parameterless constructor for " + providerClass, e);
                 }
-            });
+            }).collect(toImmutableList());
         }
     }
 }

--- a/tempto-core/src/main/java/io/prestodb/tempto/internal/ssh/JSchSshClient.java
+++ b/tempto-core/src/main/java/io/prestodb/tempto/internal/ssh/JSchSshClient.java
@@ -31,7 +31,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Supplier;
 
-import static com.google.common.collect.Iterables.transform;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.nio.file.Files.newInputStream;
 import static java.util.Objects.requireNonNull;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -157,6 +157,8 @@ public class JSchSshClient
 
     private Iterable<String> quote(List<String> command)
     {
-        return transform(command, (String s) -> "\"" + s + "\"");
+        return command.stream()
+                .map((String s) -> "\"" + s + "\"")
+                .collect(toImmutableList());
     }
 }


### PR DESCRIPTION
Hi, I modified Lists#transform method in guava to Stream#map method in java.util.stream.
Because, the following information is described in the javadoc of guava.
```
Java 8 users: many use cases for this method are better addressed by 
Stream.map(java.util.function.Function<? super T, ? extends R>). This method is not being 
deprecated, but we gently encourage you to migrate to streams.
```
detail: https://google.github.io/guava/releases/21.0/api/docs/com/google/common/collect/Lists.html#transform-java.util.List-com.google.common.base.Function-

Please check this Pull Request.
Thank you.