### PR TITLE
Upgrade testng to 7.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ build/
 out/
 *.iml
 *.eml
+*.ipr
+*.iws
 
 *.pyc
 

--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ ext.tempto_runner = project(':tempto-runner')
 ext.tempto_ldap = project(':tempto-ldap')
 ext.tempto_kafka = project(':tempto-kafka')
 ext.expected_result_generator = project(':expected-result-generator')
-ext.tempto_version = '1.52-SNAPSHOT'
+ext.tempto_version = '1.52'
 ext.tempto_group = "io.prestodb.tempto"
 ext.isReleaseVersion = !tempto_version.endsWith("SNAPSHOT")
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ ext.versions = [
         guava        : '21.0',
         guice        : '4.0',
         log4j        : '1.2.17',
-        testng       : '6.14.3',
+        testng       : '7.5',
         junit        : '4.12',
         spock        : '1.0-groovy-2.4',
         slf4j        : '1.7.12',

--- a/tempto-core/src/main/java/io/prestodb/tempto/internal/convention/ConventionBasedTestProxyGenerator.java
+++ b/tempto-core/src/main/java/io/prestodb/tempto/internal/convention/ConventionBasedTestProxyGenerator.java
@@ -25,6 +25,7 @@ import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.implementation.MethodCall;
 import org.slf4j.Logger;
+import org.testng.annotations.CustomAttribute;
 import org.testng.annotations.Test;
 
 import java.lang.annotation.Annotation;
@@ -164,12 +165,6 @@ public class ConventionBasedTestProxyGenerator
         }
 
         @Override
-        public String[] parameters()
-        {
-            return new String[0];
-        }
-
-        @Override
         public String[] dependsOnGroups()
         {
             return new String[0];
@@ -260,9 +255,9 @@ public class ConventionBasedTestProxyGenerator
         }
 
         @Override
-        public boolean sequential()
+        public CustomAttribute[] attributes()
         {
-            return false;
+            return new CustomAttribute[0];
         }
 
         @Override

--- a/tempto-core/src/main/java/io/prestodb/tempto/internal/initialization/DelegateTestNGMethod.java
+++ b/tempto-core/src/main/java/io/prestodb/tempto/internal/initialization/DelegateTestNGMethod.java
@@ -15,13 +15,16 @@
 package io.prestodb.tempto.internal.initialization;
 
 import org.testng.IClass;
+import org.testng.IDataProviderMethod;
 import org.testng.IRetryAnalyzer;
 import org.testng.ITestClass;
 import org.testng.ITestNGMethod;
+import org.testng.ITestResult;
+import org.testng.annotations.CustomAttribute;
 import org.testng.internal.ConstructorOrMethod;
+import org.testng.internal.IParameterInfo;
 import org.testng.xml.XmlTest;
 
-import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -55,23 +58,9 @@ public abstract class DelegateTestNGMethod
     }
 
     @Override
-    @Deprecated
-    public Method getMethod()
-    {
-        return delegate.getMethod();
-    }
-
-    @Override
     public String getMethodName()
     {
         return delegate.getMethodName();
-    }
-
-    @Override
-    @Deprecated
-    public Object[] getInstances()
-    {
-        return delegate.getInstances();
     }
 
     @Override
@@ -225,12 +214,6 @@ public abstract class DelegateTestNGMethod
     }
 
     @Override
-    public int getTotalInvocationCount()
-    {
-        return delegate.getTotalInvocationCount();
-    }
-
-    @Override
     public int getSuccessPercentage()
     {
         return delegate.getSuccessPercentage();
@@ -324,18 +307,6 @@ public abstract class DelegateTestNGMethod
     public int getParameterInvocationCount()
     {
         return delegate.getParameterInvocationCount();
-    }
-
-    @Override
-    public IRetryAnalyzer getRetryAnalyzer()
-    {
-        return delegate.getRetryAnalyzer();
-    }
-
-    @Override
-    public void setRetryAnalyzer(IRetryAnalyzer retryAnalyzer)
-    {
-        delegate.setRetryAnalyzer(retryAnalyzer);
     }
 
     @Override
@@ -448,4 +419,76 @@ public abstract class DelegateTestNGMethod
 
     @Override
     abstract public ITestNGMethod clone();
+
+    @Override
+    public boolean hasBeforeGroupsConfiguration()
+    {
+        return delegate.hasBeforeGroupsConfiguration();
+    }
+
+    @Override
+    public boolean hasAfterGroupsConfiguration()
+    {
+        return delegate.hasAfterGroupsConfiguration();
+    }
+
+    @Override
+    public boolean isDataDriven()
+    {
+        return delegate.isDataDriven();
+    }
+
+    @Override
+    public IParameterInfo getFactoryMethodParamsInfo()
+    {
+        return delegate.getFactoryMethodParamsInfo();
+    }
+
+    @Override
+    public CustomAttribute[] getAttributes()
+    {
+        return delegate.getAttributes();
+    }
+
+    @Override
+    public IDataProviderMethod getDataProviderMethod()
+    {
+        return delegate.getDataProviderMethod();
+    }
+
+    @Override
+    public Class<?>[] getParameterTypes()
+    {
+        return delegate.getParameterTypes();
+    }
+
+    @Override
+    public IRetryAnalyzer getRetryAnalyzer(ITestResult result)
+    {
+        return delegate.getRetryAnalyzer(result);
+    }
+
+    @Override
+    public void setRetryAnalyzerClass(Class<? extends IRetryAnalyzer> clazz)
+    {
+        delegate.setRetryAnalyzerClass(clazz);
+    }
+
+    @Override
+    public Class<? extends IRetryAnalyzer> getRetryAnalyzerClass()
+    {
+        return delegate.getRetryAnalyzerClass();
+    }
+
+    @Override
+    public int getInterceptedPriority()
+    {
+        return delegate.getInterceptedPriority();
+    }
+
+    @Override
+    public void setInterceptedPriority(int priority)
+    {
+        delegate.setInterceptedPriority(priority);
+    }
 }


### PR DESCRIPTION
TestNG has lot of breaking API changes.
This adapts to the new interfaces.
Presto will be upgraded to testng 7.5

Tests-
Existing tests, no logical changes.