### PR TITLE
Prepare 1.53 development release iteration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ ext.tempto_runner = project(':tempto-runner')
 ext.tempto_ldap = project(':tempto-ldap')
 ext.tempto_kafka = project(':tempto-kafka')
 ext.expected_result_generator = project(':expected-result-generator')
-ext.tempto_version = '1.52'
+ext.tempto_version = '1.53-SNAPSHOT'
 ext.tempto_group = "io.prestodb.tempto"
 ext.isReleaseVersion = !tempto_version.endsWith("SNAPSHOT")
 


### PR DESCRIPTION
Prepare for 1.53 development release iteration.
1.52 is released 
https://search.maven.org/artifact/io.prestodb.tempto/tempto-core/1.52/jar

Tests -
Existing tests.