### PR TITLE
Prepare 1.53 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ ext.tempto_runner = project(':tempto-runner')
 ext.tempto_ldap = project(':tempto-ldap')
 ext.tempto_kafka = project(':tempto-kafka')
 ext.expected_result_generator = project(':expected-result-generator')
-ext.tempto_version = '1.53-SNAPSHOT'
+ext.tempto_version = '1.53'
 ext.tempto_group = "io.prestodb.tempto"
 ext.isReleaseVersion = !tempto_version.endsWith("SNAPSHOT")
 

--- a/tempto-core/src/main/java/io/prestodb/tempto/internal/convention/ConventionBasedTestProxyGenerator.java
+++ b/tempto-core/src/main/java/io/prestodb/tempto/internal/convention/ConventionBasedTestProxyGenerator.java
@@ -25,8 +25,10 @@ import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.implementation.MethodCall;
 import org.slf4j.Logger;
+import org.testng.IRetryAnalyzer;
 import org.testng.annotations.CustomAttribute;
 import org.testng.annotations.Test;
+import org.testng.internal.annotations.DisabledRetryAnalyzer;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
@@ -267,9 +269,9 @@ public class ConventionBasedTestProxyGenerator
         }
 
         @Override
-        public Class retryAnalyzer()
+        public Class<? extends IRetryAnalyzer> retryAnalyzer()
         {
-            return Class.class;
+            return DisabledRetryAnalyzer.class;
         }
 
         @Override

--- a/tempto-core/src/main/java/io/prestodb/tempto/process/LocalCliProcess.java
+++ b/tempto-core/src/main/java/io/prestodb/tempto/process/LocalCliProcess.java
@@ -16,7 +16,9 @@ package io.prestodb.tempto.process;
 import io.prestodb.tempto.internal.process.CliProcessBase;
 
 import java.time.Duration;
+import java.util.OptionalInt;
 
+import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
@@ -26,11 +28,18 @@ public class LocalCliProcess
         extends CliProcessBase
 {
     private final Process process;
+    private final OptionalInt expectedExitValue;
 
-    public LocalCliProcess(Process process)
+    public LocalCliProcess(Process process, OptionalInt expectedExitValue)
     {
         super(process.getInputStream(), process.getErrorStream(), process.getOutputStream());
         this.process = process;
+        this.expectedExitValue = requireNonNull(expectedExitValue, "expectedExitValue is null");
+    }
+
+    public LocalCliProcess(Process process)
+    {
+        this(process, OptionalInt.empty());
     }
 
     @Override
@@ -43,7 +52,7 @@ public class LocalCliProcess
         }
 
         int exitValue = process.exitValue();
-        if (exitValue != 0) {
+        if (exitValue != 0 && exitValue != expectedExitValue.orElse(0)) {
             throw new RuntimeException("Child process exited with non-zero code: " + exitValue);
         }
     }


### PR DESCRIPTION
TestNG upgrade to 7.5 is failing with RetryAnalyzer bug.
RetryAnalyzer masks the real bug, but this fix will expose
the real bug.

Tests -
Existing tests.