### PR TITLE
Upgrade jsch from 0.1.52 to 0.1.55 to fix CVE-2016-5725

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ ext.versions = [
         presto       : '0.181',
         reflections  : '0.9.9',
         bytebuddy    : '0.7-rc2',
-        jsch         : '0.1.52',
+        jsch         : '0.1.55',
         mina_sshd    : '0.14.0',
         freemarker   : '2.3.22',
         objenesis    : '1.4',


### PR DESCRIPTION
**Description**

Upgrade jsch from 0.1.52 to 0.1.55 to fix CVE-2016-5725

Upgrading the jsch library from version 0.1.52 to 0.1.55 addresses CVE-2016-5725, which is a directory traversal vulnerability in JCraft JSch before version 0.1.54. This vulnerability allowed remote SFTP servers to write to arbitrary files on Windows when using ChannelSftp.OVERWRITE mode, via a ..\ (dot dot backslash) in a recursive GET command.

Build Successful.
<img width="802" alt="Screenshot 2024-12-05 at 2 11 34 PM" src="https://github.com/user-attachments/assets/df086c5d-6437-48d8-8687-8a635700f477">

