### PR TITLE
Add GitHub Action for Gradle build in Java CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,38 @@
+name: Java CI with Gradle
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        java-version:
+          - 8
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
+          fetch-depth: 0
+
+      # Step to set up JDK
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: 'temurin'
+          cache: gradle
+
+      # Step to set up gradle.properties
+      - name: Set up gradle.properties
+        run: |
+          echo "skipSigning=false" >> gradle.properties
+
+      # Step to run Gradle build
+      - name: Gradle Build
+        run: ./gradlew build


### PR DESCRIPTION
Added a GitHub Action workflow to run Gradle build for the prestodb/tempto repository. This action automates the CI process for Java projects and ensures consistency in builds for every push and pull request to the master branch.

The workflow includes:
- Using Ubuntu-latest as the build runner.
- Setting up JDK using actions/setup-java@v4 with Temurin distribution.
- Configuring gradle.properties for build settings.
- Executing the Gradle build process with ./gradlew build.

Also updated .gitignore to exclude:
- The .gradle/ directory while retaining gradle.properties.
- The build/ directory.

This enhancement streamlines the build process.

PR: https://github.com/Dilli-Babu-Godari/tempto/pull/2 
This PR serves as proof that the CI configuration functions correctly.