### PR TITLE
Add github action to release tempto

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,13 +66,13 @@ jobs:
         run: |
           latest_tag=${{ env.latest_tag }}
           # Get commits between the latest tag and HEAD, excluding changelog commits
-          changelog=$(git log $latest_tag..HEAD --oneline --pretty=format:"- %s" | grep -v "Update CHANGELOG.md for version")
+          changelog=$(git log $latest_tag..HEAD --oneline --pretty=format:"- %s" | grep -v "Update CHANGELOG.md and gradle.properties")
           echo "Generating CHANGELOG.md"
           echo -e "## Changelog for ${{ env.new_tag }}\n\n$changelog\n" > CHANGELOG.md
           # Display the generated changelog
           cat CHANGELOG.md
 
-      - name: Update version in build.gradle
+      - name: Update release version in build.gradle
         run: |
           # Update the version in build.gradle
           sed -i "s/ext.tempto_version = '.*'/ext.tempto_version = '${{ env.new_tag }}'/" build.gradle
@@ -91,21 +91,26 @@ jobs:
           git add CHANGELOG.md build.gradle
           git commit -m "Update CHANGELOG.md and build.gradle for version ${{ env.new_tag }}"
 
-      - name: Set up gradle.properties
+      - name: Set up GPG key
         run: |
-          cat << EOF > gradle.properties
-          skipSigning=false
-          signing.keyId=${{ secrets.SIGNING_KEY_ID }}
-          signing.password=${{ secrets.SIGNING_PASSWORD }}
-          signing.secretKeyRingFile=${{ secrets.SIGNING_SECRET_KEY_RING_FILE }}
-          nexusUsername=${{ secrets.NEXUS_USERNAME }}
-          nexusPassword=${{ secrets.NEXUS_PASSWORD }}
-          EOF
+          echo "${{ secrets.GPG_SECRET }}" > ${{ github.workspace }}/secret-key.gpg
+          chmod 600 ${{ github.workspace }}/secret-key.gpg
+
+      - name: Set up gradle.properties for publishing
+        run: |
+          echo "skipSigning=false" > gradle.properties
+          echo "signing.keyId=${{ secrets.GPG_KEYID }}" >> gradle.properties
+          echo "signing.password=${{ secrets.GPG_PASSPHRASE }}" >> gradle.properties
+          echo "signing.secretKeyRingFile=${{ github.workspace }}/secret-key.gpg" >> gradle.properties
+          echo "nexusUsername=${{ vars.NEXUS_USERNAME }}" >> gradle.properties
+          echo "nexusPassword=${{ secrets.NEXUS_PASSWORD }}" >> gradle.properties
 
       - name: Publish release
         run: |
-          # TODO: remove echo after testing
-          echo ./gradlew publish
+          cat gradle.properties
+          export NEXUS_USERNAME=${{ vars.NEXUS_USERNAME }}
+          export NEXUS_PASSWORD=${{ secrets.NEXUS_PASSWORD }}
+          ./gradlew publish
       
       - name: Push changes and tags
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,63 +33,62 @@ jobs:
           distribution: 'temurin'
           cache: gradle
 
-      - name: Set up gradle.properties
+      - name: Set up git
         run: |
-          echo "skipSigning=false" >> gradle.properties
-
-      - name: Test Gradle Build
-        run: ./gradlew build
-
-      - name: Get latest release tag
-        id: get_latest_tag
-        run: |
-          # Get the latest tag
-          latest_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0")
-          echo "Latest tag: $latest_tag"
-          echo "latest_tag=$latest_tag" >> $GITHUB_ENV
-
-      - name: Advance release version
-        id: advance_version          
-        run: |
-          latest_tag=${{ env.latest_tag }}
-          # Parse the version number (e.g., 1.52)
-          major=$(echo $latest_tag | cut -d. -f1)
-          minor=$(echo $latest_tag | cut -d. -f2)
-          # Increment the minor version
-          new_minor=$((minor + 1))
-          new_tag="$major.$new_minor"
-          echo "New tag: $new_tag"
-          echo "new_tag=$new_tag" >> $GITHUB_ENV
-
-      - name: Generate CHANGELOG.md
-        id: generate_changelog
-        run: |
-          latest_tag=${{ env.latest_tag }}
-          # Get commits between the latest tag and HEAD, excluding changelog commits
-          changelog=$(git log $latest_tag..HEAD --oneline --pretty=format:"- %s" | grep -v "Update CHANGELOG.md and gradle.properties")
-          echo "Generating CHANGELOG.md"
-          echo -e "## Changelog for ${{ env.new_tag }}\n\n$changelog\n" > CHANGELOG.md
-          # Display the generated changelog
-          cat CHANGELOG.md
-
-      - name: Update release version in build.gradle
-        run: |
-          # Update the version in build.gradle
-          sed -i "s/ext.tempto_version = '.*'/ext.tempto_version = '${{ env.new_tag }}'/" build.gradle
-
-      - name: Add release tag
-        run: |
-          # Configure git user
           git config --global --add safe.directory ${{github.workspace}}
           git config --global user.email "ci@lists.prestodb.io"
           git config --global user.name "prestodb-ci"
           git config pull.rebase false
-          git tag -a ${{ env.new_tag }} -m "Release ${{ env.new_tag }}"
 
-      - name: Commit changes
+      - name: Run gradle build
         run: |
+          echo "skipSigning=false" > gradle.properties
+          ./gradlew build
+
+      - name: Get release version
+        id: get_release_version
+        run: |
+          release_version=$(grep "^ext.tempto_version" build.gradle | cut -d"'" -f2 | sed 's/-SNAPSHOT//')
+          echo "release_version=$release_version"
+          echo "release_version=$release_version" >> $GITHUB_ENV
+          echo "next_release_msg=Update build.gradle to next development version" >> $GITHUB_ENV
+
+      - name: Get last release version
+        id: advance_version          
+        run: |
+          release_version=${{ env.release_version }}
+          # Parse the version number (e.g., 1.52)
+          major=$(echo $release_version | cut -d. -f1)
+          minor=$(echo $release_version | cut -d. -f2)
+          # Increment the minor version
+          last_minor=$((minor - 1))
+          last_version="$major.$last_minor"
+          echo "last_version=$last_version" >> $GITHUB_ENV
+          next_minor=$((minor + 1))
+          next_version="$major.$next_minor-SNAPSHOT"
+          echo "next_version=$next_version" >> $GITHUB_ENV
+          echo "last_version=$last_version"
+          echo "next_version=$next_version"
+
+      - name: Generate CHANGELOG.md
+        id: generate_changelog
+        run: |
+          # Get commits between the latest version and HEAD, excluding changelog commits
+          changelog=$(git log $last_version..HEAD --pretty=format:"- [%h](https://github.com/${{ github.repository }}/commit/%H) %s" | grep -v "${{ env.next_release_msg }}")
+          echo "Generating CHANGELOG.md"
+          echo -e "## Changelog for ${{ env.release_version }}\n\n$changelog\n" > CHANGELOG.md
+          cat CHANGELOG.md
+
+      - name: Update release version and commit
+        run: |
+          # Update the version in build.gradle
+          sed -i "s/ext.tempto_version = '.*'/ext.tempto_version = '${{ env.release_version }}'/" build.gradle
           git add CHANGELOG.md build.gradle
-          git commit -m "Update CHANGELOG.md and build.gradle for version ${{ env.new_tag }}"
+          git commit -m "Update CHANGELOG.md and build.gradle for version ${{ env.release_version }}"
+
+      - name: Add release tag
+        run: |
+          git tag -a ${{ env.release_version }} -m "Release ${{ env.release_version }}"
 
       - name: Set up GPG key
         run: |
@@ -112,6 +111,13 @@ jobs:
           export NEXUS_PASSWORD=${{ secrets.NEXUS_PASSWORD }}
           ./gradlew publish
       
+      - name: Update release version in build.gradle
+        run: |
+          # Update the version in build.gradle
+          sed -i "s/ext.tempto_version = '.*'/ext.tempto_version = '${{ env.next_version}}'/" build.gradle
+          git add build.gradle
+          git commit -m "${{ env.next_release_msg }}"
+
       - name: Push changes and tags
         run: |
           git push origin master --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,13 +101,13 @@ jobs:
           echo "signing.keyId=${{ secrets.GPG_KEYID }}" >> gradle.properties
           echo "signing.password=${{ secrets.GPG_PASSPHRASE }}" >> gradle.properties
           echo "signing.secretKeyRingFile=${{ github.workspace }}/secret-key.gpg" >> gradle.properties
-          echo "nexusUsername=${{ vars.NEXUS_USERNAME }}" >> gradle.properties
+          echo "nexusUsername=${{ secrets.NEXUS_USERNAME }}" >> gradle.properties
           echo "nexusPassword=${{ secrets.NEXUS_PASSWORD }}" >> gradle.properties
 
       - name: Publish release
         run: |
           cat gradle.properties
-          export NEXUS_USERNAME=${{ vars.NEXUS_USERNAME }}
+          export NEXUS_USERNAME=${{ secrets.NEXUS_USERNAME }}
           export NEXUS_PASSWORD=${{ secrets.NEXUS_PASSWORD }}
           ./gradlew publish
       

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,10 @@ jobs:
           # Parse the version number (e.g., 1.52)
           major=$(echo $release_version | cut -d. -f1)
           minor=$(echo $release_version | cut -d. -f2)
+          if [ "$minor" -eq "0" ]; then
+            echo "Warning: This action does not handle a new major version."
+            exit 1
+          fi
           # Increment the minor version
           last_minor=$((minor - 1))
           last_version="$major.$last_minor"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,112 @@
+name: Publish tempto release
+
+on:
+  workflow_dispatch: # Allows manual triggering of the workflow
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+    environment: release
+    strategy:
+      fail-fast: true
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: Check branch
+        if: ${{ github.ref != 'refs/heads/master' }}
+        run: echo "Invalid branch. This action can only be run on the master branch." && exit 1
+
+      - name: Checkout tempto source
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PRESTODB_CI_TOKEN }}
+          show-progress: false
+          fetch-depth: 0
+          ref: master
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 8
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Set up gradle.properties
+        run: |
+          echo "skipSigning=false" >> gradle.properties
+
+      - name: Test Gradle Build
+        run: ./gradlew build
+
+      - name: Get latest release tag
+        id: get_latest_tag
+        run: |
+          # Get the latest tag
+          latest_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0")
+          echo "Latest tag: $latest_tag"
+          echo "latest_tag=$latest_tag" >> $GITHUB_ENV
+
+      - name: Advance release version
+        id: advance_version          
+        run: |
+          latest_tag=${{ env.latest_tag }}
+          # Parse the version number (e.g., 1.52)
+          major=$(echo $latest_tag | cut -d. -f1)
+          minor=$(echo $latest_tag | cut -d. -f2)
+          # Increment the minor version
+          new_minor=$((minor + 1))
+          new_tag="$major.$new_minor"
+          echo "New tag: $new_tag"
+          echo "new_tag=$new_tag" >> $GITHUB_ENV
+
+      - name: Generate CHANGELOG.md
+        id: generate_changelog
+        run: |
+          latest_tag=${{ env.latest_tag }}
+          # Get commits between the latest tag and HEAD, excluding changelog commits
+          changelog=$(git log $latest_tag..HEAD --oneline --pretty=format:"- %s" | grep -v "Update CHANGELOG.md for version")
+          echo "Generating CHANGELOG.md"
+          echo -e "## Changelog for ${{ env.new_tag }}\n\n$changelog\n" > CHANGELOG.md
+          # Display the generated changelog
+          cat CHANGELOG.md
+
+      - name: Update version in build.gradle
+        run: |
+          # Update the version in build.gradle
+          sed -i "s/ext.tempto_version = '.*'/ext.tempto_version = '${{ env.new_tag }}'/" build.gradle
+
+      - name: Add release tag
+        run: |
+          # Configure git user
+          git config --global --add safe.directory ${{github.workspace}}
+          git config --global user.email "ci@lists.prestodb.io"
+          git config --global user.name "prestodb-ci"
+          git config pull.rebase false
+          git tag -a ${{ env.new_tag }} -m "Release ${{ env.new_tag }}"
+
+      - name: Commit changes
+        run: |
+          git add CHANGELOG.md build.gradle
+          git commit -m "Update CHANGELOG.md and build.gradle for version ${{ env.new_tag }}"
+
+      - name: Set up gradle.properties
+        run: |
+          cat << EOF > gradle.properties
+          skipSigning=false
+          signing.keyId=${{ secrets.SIGNING_KEY_ID }}
+          signing.password=${{ secrets.SIGNING_PASSWORD }}
+          signing.secretKeyRingFile=${{ secrets.SIGNING_SECRET_KEY_RING_FILE }}
+          nexusUsername=${{ secrets.NEXUS_USERNAME }}
+          nexusPassword=${{ secrets.NEXUS_PASSWORD }}
+          EOF
+
+      - name: Publish release
+        run: |
+          # TODO: remove echo after testing
+          echo ./gradlew publish
+      
+      - name: Push changes and tags
+        run: |
+          git push origin master --tags


### PR DESCRIPTION
This PR is sitll in progress.

Testing action in this repo => https://github.com/unix280/tempto/actions/workflows/release.yml

Test passed with test GPG key and test maven repo => https://github.com/unix280/tempto/actions/runs/13102076676

Environment setup:

1. In the repo settings-> **Environment**, create a new environment named `release`
2. In the enviroment settings, check **Required reviewers**, and select reviewers 
3. Create the Environment secrets in the `release` environment settings
-  PRESTODB_CI_TOKEN - token of prestodb-ci to push the commits
-  GPG_SECRET - GPG private key
-  GPG_KEYID - GPG key ID
-  GPG_PASSPHRASE - GPG key passphrase
-  NEXUS_PASSWORD - Password for Nexus repository
- NEXUS_USERNAME - Username for Nexus repository
