### PR TITLE
Remove maven snapshot repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -196,14 +196,6 @@ configure(subprojects - expected_result_generator - tempto_examples) {
                     password = System.getenv('NEXUS_PASSWORD')
                 }
             }
-
-            maven {
-                url = uri('https://oss.sonatype.org/content/repositories/snapshots/')
-                credentials {
-                    username = System.getenv('NEXUS_USERNAME')
-                    password = System.getenv('NEXUS_PASSWORD')
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
Fix http error 400, ref => https://central.sonatype.org/faq/400-error/#question

```
> Task :tempto-core:publishMavenPublicationToMaven2Repository FAILED
[Incubating] Problems report is available at: file:///home/runner/work/tempto/tempto/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.11.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
6 actionable tasks: 4 executed, 2 up-to-date
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':tempto-core:publishMavenPublicationToMaven2Repository'.
> Failed to publish publication 'maven' to repository 'maven2'
   > Could not PUT 'https://oss.sonatype.org/content/repositories/snapshots/io/prestodb/tempto/tempto-core/1.54/tempto-core-1.54.jar'. Received status code 400 from server: Bad Request
```