### PR TITLE
fix(ci): Fix sign error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,12 +114,12 @@ jobs:
           echo "nexusUsername=${{ secrets.NEXUS_USERNAME }}" >> gradle.properties
           echo "nexusPassword=${{ secrets.NEXUS_PASSWORD }}" >> gradle.properties
 
-      - name: Sign and publish release
+      - name: publish release
         run: |
           cat gradle.properties
           export NEXUS_USERNAME="${{ secrets.NEXUS_USERNAME }}"
           export NEXUS_PASSWORD="${{ secrets.NEXUS_PASSWORD }}"
-          ./gradlew sign publish publishToMavenCentral
+          ./gradlew publish publishToMavenCentral
         env:
           GPG_TTY: $(tty)
 


### PR DESCRIPTION
Fix the CI error:

```log
FAILURE: Build failed with an exception.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.
* What went wrong:

Task 'sign' not found in root project 'tempto' and its subprojects.
You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
```

Tested with(401 is as expected since no token there) :https://github.com/unix280/tempto/actions/runs/27118238373/job/80029399433